### PR TITLE
Added  to reference, bug 1134264

### DIFF
--- a/api.js
+++ b/api.js
@@ -900,7 +900,7 @@ API.prototype.reference = function(options) {
   var reference = {
     version:            0,
     '$schema':          'http://schemas.taskcluster.net/base/v1/' +
-                        'api-reference.json',
+                        'api-reference.json#',
     title:              this._options.title,
     description:        this._options.description,
     baseUrl:            options.baseUrl,

--- a/api.js
+++ b/api.js
@@ -898,7 +898,9 @@ API.prototype.reference = function(options) {
   assert(options,         "Options is required");
   assert(options.baseUrl, "A 'baseUrl' must be provided");
   var reference = {
-    version:            '0.2.0',
+    version:            0,
+    '$schema':          'http://schemas.taskcluster.net/base/v1/' +
+                        'api-reference.json',
     title:              this._options.title,
     description:        this._options.description,
     baseUrl:            options.baseUrl,

--- a/exchanges.js
+++ b/exchanges.js
@@ -458,7 +458,9 @@ Exchanges.prototype.reference = function(options) {
 
   // Create reference
   var reference = {
-    version:            '0.2.0',
+    version:            0,
+    '$schema':          'http://schemas.taskcluster.net/base/v1/' +
+                        'exchanges-reference.json',
     title:              options.title,
     description:        options.description,
     exchangePrefix:     exchangePrefix,

--- a/exchanges.js
+++ b/exchanges.js
@@ -460,7 +460,7 @@ Exchanges.prototype.reference = function(options) {
   var reference = {
     version:            0,
     '$schema':          'http://schemas.taskcluster.net/base/v1/' +
-                        'exchanges-reference.json',
+                        'exchanges-reference.json#',
     title:              options.title,
     description:        options.description,
     exchangePrefix:     exchangePrefix,

--- a/schemas/api-reference.json
+++ b/schemas/api-reference.json
@@ -7,7 +7,13 @@
   "properties": {
     "version": {
       "description":          "API reference version",
-      "enum":                 ["0.2.0"]
+      "enum":                 [0]
+    },
+    "$schema": {
+      "description":          "Link to schema for this reference. That is a link to this very document. Typically used to identify what kind of reference this file is.",
+      "title":                "Schema Reference",
+      "type":                 "string",
+      "format":               "uri"
     },
     "title": {
       "description":          "API title in markdown",
@@ -97,5 +103,5 @@
     }
   },
   "additionalProperties":   false,
-  "required": ["version", "title", "description", "baseUrl", "entries"]
+  "required": ["version", "$schema", "title", "description", "baseUrl", "entries"]
 }

--- a/schemas/exchanges-reference.json
+++ b/schemas/exchanges-reference.json
@@ -7,7 +7,13 @@
   "properties": {
     "version": {
       "description":          "Exchange reference version",
-      "enum":                 ["0.2.0"]
+      "enum":                 [0]
+    },
+    "$schema": {
+      "description":          "Link to schema for this reference. That is a link to this very document. Typically used to identify what kind of reference this file is.",
+      "title":                "Schema Reference",
+      "type":                 "string",
+      "format":               "uri"
     },
     "title": {
       "description":          "Title for set of exchanges in markdown",
@@ -93,5 +99,5 @@
     }
   },
   "additionalProperties":   false,
-  "required": ["version", "title", "description", "exchangePrefix", "entries"]
+  "required": ["version", "$schema", "title", "description", "exchangePrefix", "entries"]
 }


### PR DESCRIPTION
Fix for bug 1134264


I set `version: 0` as we don't need semver... And we probably want to rethink reference before we declare version 1. Specifically I imagine  we want to enable query string parameters for `get` requests... And probably also define how to stream down file with content-type that isn't JSON... And maybe look at hyper-json or swagger...

Anyways, this added `$schema`. And now client generators can check if `version` is different from `0`. In which case the generator should display a warning...