### PR TITLE
Check that exchange has title and description

### DIFF
--- a/exchanges.js
+++ b/exchanges.js
@@ -185,6 +185,8 @@ var Exchanges = function(options) {
     exchangePrefix:       '',
     durableExchanges:     true
   };
+  assert(options.title,       "title must be provided");
+  assert(options.description, "description must be provided");
   this.configure(options);
 };
 


### PR DESCRIPTION
We currently just check this in the `.reference` method which produces issues that only show up when publishing docs...