### PR TITLE
API stability-levels

### DIFF
--- a/api.js
+++ b/api.js
@@ -823,7 +823,7 @@ var STABILITY_LEVELS = _.values(stability);
  * Declare an API end-point entry, where options is on the following form:
  *
  * {
- *   method:    'post|head|put|get|delete',
+ *   method:   'post|head|put|get|delete',
  *   route:    '/object/:id/action/:param',      // URL pattern with parameters
  *   params: {                                   // Patterns for URL params
  *     param: /.../,                             // Reg-exp pattern

--- a/api.js
+++ b/api.js
@@ -742,64 +742,33 @@ var stability = {
    */
   deprecated:       'deprecated',
   /**
-   * API may change and resources may be deleted without warning
+   * Unless otherwise stated API may change and resources may be deleted
+   * without warning. Often we will, however, try to deprecate the API first
+   * and keep around as `deprecated`.
    *
    * **Intended Usage:**
    *  - Prototype API end-points,
    *  - API end-points intended displaying unimportant state.
    *    (e.g. API to fetch state from a provisioner)
-   */
-  experimental:     'experimental',
-  /**
-   * API may change, we will attempt to warn clients before breakages and
-   * resource deletion.
-   *
-   * **Intended Usage:**
    *  - Prototypes used in non-critical production by third parties,
    *  - API end-points of little public interest,
    *    (e.g. API to define workerTypes for a provisioner)
-   */
-  unstable:         'unstable',
-  /**
-   * We facilitate gradual migration when the API changes, and we monitor legacy
-   * usage, ensuring that nobody has used the legacy API for 72 hours before
-   * we remove legacy support.
    *
-   * Resources are not deleted, they may expire or/be deleted as documented,
-   * but resources will not magically disappear.
+   * Generally, this is a good stability levels for anything under-development,
+   * or when we know that there is a limited number of consumers so fixing
+   * the world after breaking the API is easy.
+   */
+  experimental:     'experimental',
+  /**
+   * API is stable and we will not delete resources or break the API suddenly.
+   * As a guideline we will always facilitate gradual migration if we change
+   * a stable API.
    *
    * **Intended Usage:**
    *  - API end-points used in critical production.
-   *
-   * Note, it is not a goal to progress API end-points beyond this
-   * stability-level unless there is good reasons to do so.
+   *  - APIs so widely used that refactoring would be hard.
    */
-  stable:           'stable',
-  /**
-   * We recognize that we can't facilitate gradual migration, as too many
-   * components depend on this API. We will not break backwards compatibility
-   * going forward. But we may still add additional features, properties, etc.
-   * In a strictly backwards compatible manner.
-   *
-   * **Intended Usage:**
-   *  - APIs so widely used that refactoring would be impossible.
-   *  - APIs whose concepts makes up the essence of TaskCluster.
-   *
-   * Note, this stability-level is only intended for widely used API end-points,
-   * where we simply don't imagine that it would be possible to track down all
-   * the clients.
-   */
-  frozen:           'frozen',
-  /**
-   * We recognize that we can't facilitate gradual migration, and that adding
-   * features, properties, etc. would be undesired. Any changes to API
-   * end-points with this stability-level are strictly internal, and invisible
-   * to clients.
-   *
-   * **Intended Usage:**
-   *  - No intended usage identified yet.
-   */
-  locked:           'locked'
+  stable:           'stable'
 };
 
 // List of valid stability-levels

--- a/schemas/api-reference.json
+++ b/schemas/api-reference.json
@@ -66,11 +66,11 @@
           },
           "stability": {
             "title":          "Stability-Level",
-            "description":    "Stability level of the API, refer to documentation for details on these levels.",
+            "description":    "Stability level of the API",
             "enum": [
-              "deprecated", "experimental",
-              "unstable", "stable",
-              "frozen", "locked"
+              "deprecated",
+              "experimental",
+              "stable"
             ]
           },
           "scopes": {

--- a/schemas/api-reference.json
+++ b/schemas/api-reference.json
@@ -64,6 +64,15 @@
             "type":           "string",
             "description":    "Name of the `function` this is a stable identifier for use in auto-generated client libraries"
           },
+          "stability": {
+            "title":          "Stability-Level",
+            "description":    "Stability level of the API, refer to documentation for details on these levels.",
+            "enum": [
+              "deprecated", "experimental",
+              "unstable", "stable",
+              "frozen", "locked"
+            ]
+          },
           "scopes": {
             "type":           "array",
             "description":    "List of scope-sets of which the client must satisfy at least one of the sets of scopes. Not provided if authentication isn't required.",
@@ -97,7 +106,8 @@
         },
         "additionalProperties":   false,
         "required": [
-          "type", "method", "route", "args", "name", "title", "description"
+          "type", "method", "route", "args",
+          "name", "stability", "title", "description"
         ]
       }
     }

--- a/test/api/publish_test.js
+++ b/test/api/publish_test.js
@@ -83,11 +83,12 @@ suite("api/publish", function() {
 
     // Declare a simple method
     api.declare({
-      method:   'get',
-      route:    '/test',
-      name:     'test',
-      title:    "Test End-Point",
+      method:       'get',
+      route:        '/test',
+      name:         'test',
+      title:        "Test End-Point",
       description:  "Place we can call to test something",
+      stability:    base.API.stability.stable
     }, function(req, res) {
       res.send(200, "Hello World");
     });


### PR DESCRIPTION
We need more tests... Just to make sure the code doesn't crash when you generate a reference for an API that uses all 6 stability-levels.
And we need to figure where to put the documentation of stability-levels on docs.taskcluster.net.
So let's not merge yet, I'm just opening the discussion...

This is inspired by [node.js stability index](https://nodejs.org/api/documentation.html#documentation_stability_index), but it's very different.
I have changed the semantics, mainly because I think we should aim to have the flexibility to make breaking changes as long as we promise to make a gradual breakage.
Ideally, we should monitor usage of the legacy code, and use the evidence that it hasn't been used for 72 hours as the measure for when we can reliably remove legacy code paths.

The idea with these stability-levels is to make some reasonable promises, without tying ourselves down in an impossible situation where we have a million old legacy code paths to maintain. For example we maintained `queue.claimWork(provisionerId, workerType, {...})` during the transition to the new queue.
But I'm glad that we could drop the end-point completely, so people can't use it anymore. Dropping legacy code also dramatically reduces the complexity of our code. And in some cases allows us to make new promises, for example the proposed migration path to 3-step artifact creation process in bug [bug 1155645](https://bugzilla.mozilla.org/show_bug.cgi?id=1155645). Once we migrate all artifact uploaders and turn off the old legacy code-path, we can promise that visible artifacts are available (that is a very useful promise to give).