### PR TITLE
Tc client stats handler

### DIFF
--- a/api.js
+++ b/api.js
@@ -15,25 +15,10 @@ require('superagent-hawk')(require('superagent'));
 var request       = require('superagent-promise');
 var Validator     = require('./validator').Validator;
 var utils         = require('./utils');
-var stats         = require('./stats');
+var stats         = require('./lib/stats');
 var crypto        = require('crypto');
 var hoek          = require('hoek');
-
-/** Structure for response times series */
-var ResponseTimes = new stats.Series({
-  name:                 'ResponseTimes',
-  columns: {
-    duration:           stats.types.Number,
-    statusCode:         stats.types.Number,
-    requestMethod:      stats.types.String,
-    method:             stats.types.String,
-    component:          stats.types.String
-  },
-  // Additional columns are req.params prefixed with "param", these should all
-  // be strings
-  additionalColumns:    stats.types.String
-});
-
+var series        = require('./lib/series');
 
 /**
  * Declare {input, output} schemas as options to validate
@@ -820,7 +805,7 @@ API.prototype.router = function(options) {
   var reporter = null;
   if (options.drain) {
     assert(options.component, "The component must be named in statistics!");
-    reporter = ResponseTimes.reporter(options.drain);
+    reporter = series.ResponseTimes.reporter(options.drain);
   }
 
   // Create router

--- a/exchanges.js
+++ b/exchanges.js
@@ -11,21 +11,7 @@ var aws           = require('aws-sdk-promise');
 var amqplib       = require('amqplib');
 var events        = require('events');
 var util          = require('util');
-var stats         = require('./stats');
-
-/** Exchange reports for statistics */
-var ExchangeReports = new stats.Series({
-  name:           'ExchangeReports',
-  columns: {
-    component:    stats.types.String, // Component name (e.g. 'queue')
-    process:      stats.types.String, // Process name (e.g. 'server')
-    duration:     stats.types.Number, // Time it took to send the message
-    routingKeys:  stats.types.Number, // 1 + number CCed routing keys
-    payloadSize:  stats.types.Number, // Size of message bytes
-    exchange:     stats.types.String, // true || false
-    error:        stats.types.String  // true || false
-  }
-});
+var series        = require('./lib/series');
 
 /** Class for publishing to a set of declared exchanges */
 var Publisher = function(conn, channel, entries, exchangePrefix, options) {
@@ -39,7 +25,7 @@ var Publisher = function(conn, channel, entries, exchangePrefix, options) {
   if (options.drain) {
     assert(options.component, "component name for statistics is required");
     assert(options.process,   "process name for statistics is required");
-    this._reporter = ExchangeReports.reporter(options.drain);
+    this._reporter = series.ExchangeReports.reporter(options.drain);
   }
 
   var that = this;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ _.forIn({
   AzureAgent:     './lib/azureagent',
   Exchanges:      './exchanges',
   testing:        './testing',
-  stats:          './stats',
+  stats:          './lib/stats',
   utils:          './utils'
 }, function(module, name) {
   Object.defineProperty(exports, name, {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -10,7 +10,7 @@ var azureTable      = require('azure-table-node');
 var azure           = require('fast-azure-storage');
 var taskcluster     = require('taskcluster-client');
 var https           = require('https');
-var stats           = require('../stats');
+var series          = require('./series');
 var AzureAgent      = require('./azureagent');
 
 // ** Coding Style **
@@ -78,19 +78,6 @@ var MAX_MODIFY_ATTEMPTS     = 10;
 
 /** Timeout for azure table requests */
 var AZURE_TABLE_TIMEOUT     = 7 * 1000;
-
-/** Statistics from Azure table operations */
-var AzureTableOperations = new stats.Series({
-  name:             'AzureTableOperations',
-  columns: {
-    component:      stats.types.String,
-    process:        stats.types.String,
-    duration:       stats.types.Number,
-    table:          stats.types.String,
-    method:         stats.types.String,
-    error:          stats.types.String
-  }
-});
 
 /**
  * Base class of all entity
@@ -612,7 +599,7 @@ Entity.setup = function(options) {
   // Reporter for statistics
   var reporter = function() {};
   if (options.drain) {
-    reporter = AzureTableOperations.reporter(options.drain);
+    reporter = series.AzureTableOperations.reporter(options.drain);
   }
 
   // Create table client wrapper, to record statistics and bind table name

--- a/lib/series.js
+++ b/lib/series.js
@@ -47,6 +47,11 @@ var Series = function(options) {
 // Export series
 exports.Series = Series;
 
+/** Returns list of columns */
+Series.prototype.columns = function() {
+  return _.keys(this._options.columns);
+};
+
 /**
  * Create a reporter function that will validate points and submit them to the
  * drain.
@@ -82,41 +87,41 @@ Series.prototype.reporter = function(drain) {
 
 /** Usage reports format for stats.monitorProcessUsage */
 exports.UsageReports = new Series({
-  name:       'UsageReports',
+  name:               'UsageReports',
   columns: {
-    component:      types.String,
-    process:        types.String,
-    cpu:            types.Number,
-    memory:         types.Number
+    component:        types.String,
+    process:          types.String,
+    cpu:              types.Number,
+    memory:           types.Number
   }
 });
 
 /** Structure for API response times series */
 exports.ResponseTimes = new Series({
-  name:                 'ResponseTimes',
+  name:               'ResponseTimes',
   columns: {
-    duration:           types.Number,
-    statusCode:         types.Number,
-    requestMethod:      types.String,
-    method:             types.String,
-    component:          types.String
+    duration:         types.Number,
+    statusCode:       types.Number,
+    requestMethod:    types.String,
+    method:           types.String,
+    component:        types.String
   },
   // Additional columns are req.params prefixed with "param", these should all
   // be strings
-  additionalColumns:    types.String
+  additionalColumns:  types.String
 });
 
 /** Exchange reports for statistics */
 exports.ExchangeReports = new Series({
-  name:           'ExchangeReports',
+  name:               'ExchangeReports',
   columns: {
-    component:    types.String, // Component name (e.g. 'queue')
-    process:      types.String, // Process name (e.g. 'server')
-    duration:     types.Number, // Time it took to send the message
-    routingKeys:  types.Number, // 1 + number CCed routing keys
-    payloadSize:  types.Number, // Size of message bytes
-    exchange:     types.String, // true || false
-    error:        types.String  // true || false
+    component:        types.String, // Component name (e.g. 'queue')
+    process:          types.String, // Process name (e.g. 'server')
+    duration:         types.Number, // Time it took to send the message
+    routingKeys:      types.Number, // 1 + number CCed routing keys
+    payloadSize:      types.Number, // Size of message bytes
+    exchange:         types.String, // true || false
+    error:            types.String  // true || false
   }
 });
 
@@ -124,23 +129,38 @@ exports.ExchangeReports = new Series({
 exports.AzureTableOperations = new Series({
   name:             'AzureTableOperations',
   columns: {
-    component:      types.String,
-    process:        types.String,
-    duration:       types.Number,
-    table:          types.String,
-    method:         types.String,
-    error:          types.String
+    component:        types.String,
+    process:          types.String,
+    duration:         types.Number,
+    table:            types.String,
+    method:           types.String,
+    error:            types.String
   }
 });
 
-/** Handler reports format for createHandlerTimer */
-exports.HandlerReports = new Series({
-  name:       'HandlerReports',
+/** Statistics from TaskCluster Client stats callback */
+exports.APIClientCalls = new Series({
+  name:               'APIClientCalls ',
   columns: {
-    component:      types.String,
-    duration:       types.Number,
-    exchange:       types.String,
-    redelivered:    types.String,   // true || false
-    error:          types.String    // true || false
+    duration:         types.Number, // Duration of call in ms including retries
+    retries:          types.Number, // Number of retries
+    method:           types.String, // Name of method (signature)
+    success:          types.Number, // 1 or 0
+    resolution:       types.String, // http-<status> or err.code
+    target:           types.String, // Queue, Index (class name if available)
+    baseUrl:          types.String  // BaseUrl
+  },
+  additionalColumns:  types.String  // workerType, workerId, component, process
+});
+
+/** Handler reports format for stats.createHandlerTimer */
+exports.HandlerReports = new Series({
+  name:               'HandlerReports',
+  columns: {
+    component:        types.String,
+    duration:         types.Number,
+    exchange:         types.String,
+    redelivered:      types.String,   // true || false
+    error:            types.String    // true || false
   }
 });

--- a/lib/series.js
+++ b/lib/series.js
@@ -1,0 +1,146 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+
+/** Types supported for reporting */
+var types = {
+  String: function(v) { return /string/.test(typeof(v)); },
+  Number: function(v) { return /number/.test(typeof(v)); },
+  Any:    function(v) { return /string|number/.test(typeof(v)); }
+};
+
+// Export types
+exports.types = types;
+
+/**
+ * Create a times series that you can report to.
+ *
+ * options:
+ * {
+ *   // Name of the series in influxdb
+ *   name:               'ResponseTimes',
+ *
+ *   // Required columns
+ *   columns: {
+ *     method:           stats.types.String,
+ *     duration:         stats.types.Number,
+ *     custom:           stats.types.Any
+ *   },
+ *
+ *   // Type of additional columns if they are allowed (defaults `null`)
+ *   additionalColumns:  stats.types.String
+ * }
+ */
+var Series = function(options) {
+  // Validate options
+  assert(options,         "options are required");
+  assert(options.name,    "Series must be named");
+  options = _.defaults({}, options, {
+    columns:              {},
+    additionalColumns:    null
+  });
+
+  // Store options
+  this._options = options;
+};
+
+// Export series
+exports.Series = Series;
+
+/**
+ * Create a reporter function that will validate points and submit them to the
+ * drain.
+ */
+Series.prototype.reporter = function(drain) {
+  var options = this._options;
+
+  // Return a reporter
+  return function(point) {
+    // Validate that
+    _.forIn(point, function(value, key) {
+      var validate = options.columns[key] || options.additionalColumns;
+      if (!validate) {
+        debug("additionalColumn %s not allowed in series: %s",
+              key, options.name);
+        throw new Error("additionalColumn " + key + " is not allowed!");
+      }
+      if (!validate(value)) {
+        debug("Failed validate %s for key %s in series: %s",
+              value, key, options.name);
+        throw new Error("Failed validate key " + key + " in series: " +
+                        options.name);
+      }
+    });
+
+    // If validated we'll add the point to the drain
+    drain.addPoint(options.name, point);
+  };
+};
+
+
+/** Collection of statistics series used in taskcluster-base */
+
+/** Usage reports format for stats.monitorProcessUsage */
+exports.UsageReports = new Series({
+  name:       'UsageReports',
+  columns: {
+    component:      types.String,
+    process:        types.String,
+    cpu:            types.Number,
+    memory:         types.Number
+  }
+});
+
+/** Structure for API response times series */
+exports.ResponseTimes = new Series({
+  name:                 'ResponseTimes',
+  columns: {
+    duration:           types.Number,
+    statusCode:         types.Number,
+    requestMethod:      types.String,
+    method:             types.String,
+    component:          types.String
+  },
+  // Additional columns are req.params prefixed with "param", these should all
+  // be strings
+  additionalColumns:    types.String
+});
+
+/** Exchange reports for statistics */
+exports.ExchangeReports = new Series({
+  name:           'ExchangeReports',
+  columns: {
+    component:    types.String, // Component name (e.g. 'queue')
+    process:      types.String, // Process name (e.g. 'server')
+    duration:     types.Number, // Time it took to send the message
+    routingKeys:  types.Number, // 1 + number CCed routing keys
+    payloadSize:  types.Number, // Size of message bytes
+    exchange:     types.String, // true || false
+    error:        types.String  // true || false
+  }
+});
+
+/** Statistics from Azure table operations */
+exports.AzureTableOperations = new Series({
+  name:             'AzureTableOperations',
+  columns: {
+    component:      types.String,
+    process:        types.String,
+    duration:       types.Number,
+    table:          types.String,
+    method:         types.String,
+    error:          types.String
+  }
+});
+
+/** Handler reports format for createHandlerTimer */
+exports.HandlerReports = new Series({
+  name:       'HandlerReports',
+  columns: {
+    component:      types.String,
+    duration:       types.Number,
+    exchange:       types.String,
+    redelivered:    types.String,   // true || false
+    error:          types.String    // true || false
+  }
+});

--- a/test/stats_test.js
+++ b/test/stats_test.js
@@ -92,7 +92,6 @@ suite('stats', function() {
     });
 
     return p;
-
   });
 
   test("Create reporter", function() {
@@ -155,6 +154,76 @@ suite('stats', function() {
     });
   });
 
+  test("Create reporter (with tags)", function() {
+    // Create test series
+    var TestSeries = new base.stats.Series({
+      name:               'TestSeries',
+      columns: {
+        colA:             base.stats.types.String,
+        colB:             base.stats.types.Number,
+      }
+    });
+
+    // Create statistics drain with NullDrain
+    var drain = new base.stats.NullDrain();
+
+    // Create reporter
+    var reporter = TestSeries.reporter(drain, {
+      colA: 'my-tag'
+    });
+
+    var lastPoint = null;
+    drain.on('point', function(series, point) {
+      assert(lastPoint === null, "Only expected one point");
+      lastPoint = point;
+    });
+
+    // Report with reporter
+    reporter({
+      colB:   123
+    });
+
+    assert(drain.pendingPoints() === 1, "We should have 1 point");
+    assert(lastPoint, "Expected a lastPoint");
+    assert(lastPoint.colB === 123, "Expected 123 from colB");
+    assert(lastPoint.colA === 'my-tag', "Expected tag to be present");
+  });
+
+  test("Create reporter (with tags - overwrite tag)", function() {
+    // Create test series
+    var TestSeries = new base.stats.Series({
+      name:               'TestSeries',
+      columns: {
+        colA:             base.stats.types.String,
+        colB:             base.stats.types.Number,
+      }
+    });
+
+    // Create statistics drain with NullDrain
+    var drain = new base.stats.NullDrain();
+
+    // Create reporter
+    var reporter = TestSeries.reporter(drain, {
+      colA: 'my-tag'
+    });
+
+    var lastPoint = null;
+    drain.on('point', function(series, point) {
+      assert(lastPoint === null, "Only expected one point");
+      lastPoint = point;
+    });
+
+    // Report with reporter
+    reporter({
+      colB: 123,
+      colA: 'my-tag2'
+    });
+
+    assert(drain.pendingPoints() === 1, "We should have 1 point");
+    assert(lastPoint, "Expected a lastPoint");
+    assert(lastPoint.colB === 123, "Expected 123 from colB");
+    assert(lastPoint.colA === 'my-tag2', "Expected tag to be present");
+  });
 
   test("Report wrong columns", function() {
     // Create test series

--- a/test/stats_test.js
+++ b/test/stats_test.js
@@ -489,6 +489,58 @@ suite('stats', function() {
       assert(influx.pendingPoints() === 1, "We should have one point");
     });
   });
+
+  test("createAPIClientStatsHandler", function() {
+    // Create statistics drain with NullDrain
+    var drain = new base.stats.NullDrain();
+
+    // Create handler to test
+    var handler = base.stats.createAPIClientStatsHandler({
+      drain: drain,
+      tags: {
+        component: 'base-tests',
+        process: 'mocha',
+        provisionerId: 'no-provisioner',
+        workerType: 'dummy-base-test',
+        workerGroup: 'not-a-worker',
+        workerId: 'not-a-worker'
+      }
+    });
+
+    assert(drain.pendingPoints() === 0, "We should have zero points");
+
+    handler({
+      duration: 6230,
+      retries: 5,
+      method: 'getConnectionError',
+      success: 0,
+      resolution: 'ECONNRESET',
+      target: 'Unknown',
+      baseUrl: 'http://localhost:60526/v1'
+    });
+
+    assert(drain.pendingPoints() === 1, "We should have one point");
+  });
+
+  test("createAPIClientStatsHandler (illegal columns)", function() {
+    // Create statistics drain with NullDrain
+    var drain = new base.stats.NullDrain();
+
+    try {
+      base.stats.createAPIClientStatsHandler({
+        drain: drain,
+        tags: {
+          component: 'base-tests',
+          process: 'mocha',
+          method: 'can-t-declare-this'
+        }
+      });
+    } catch (err) {
+      assert(err, "Expected an error");
+      return;
+    }
+    assert(false, "Expected an error!");
+  });
 });
 
 


### PR DESCRIPTION
The stats handler setup on the `taskcluster-base` side of this...

Usage is basically:
```js
var queue = new taskcluster.Queue({
  credentials, ..., // usual config
  stats: base.stats.createAPIClientStatsHandler({
    tags: { // all component specific columns/tags
      component:      'docker-worker',
      process:        'main',
      workerType:     '...',
      provisionerId:  '...'
    }
    drain: new base.stats.Influx(...)
  })
});
```

Please let me know if docs aren't clear.. Maybe we need to add an example...