### PR TITLE
Add tests for utils.scopeMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Code Conventions
  * Return promises whenever asynchronous I/O is needed
 
 
+Testing
+-------
+
+Some of the tests for this package require external access and credentials.
+These tests are run by the usual `npm test`.  To get a copy of the credentials,
+contact Jonas.
+
+To run just the tests which do not require external access or credentials, use
+`npm run-script test-local`.
+
 Metadata Publication
 --------------------
 _We publish metadata for consumption by auto-generated clients and docs._

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description":  "Common modules for taskcluster components",
   "license":      "MPL-2.0",
   "scripts": {
-    "test":   "./test/runtests.sh"
+    "test-local":   "./test/runtests.sh local",
+    "test":   "./test/runtests.sh full"
   },
   "repository": {
     "type":   "git",

--- a/test/api/publish_test.js
+++ b/test/api/publish_test.js
@@ -29,8 +29,8 @@ suite("api/publish", function() {
     });
 
     if (!cfg.get('aws') || !cfg.get('referenceTestBucket')) {
-      console.log("Skipping 'publish', missing config file: " +
-                  "taskcluster-base-test.conf.json");
+      throw new Error("Skipping 'publish', missing config file: " +
+                      "taskcluster-base-test.conf.json");
       return;
     }
 
@@ -70,8 +70,8 @@ suite("api/publish", function() {
     });
 
     if (!cfg.get('aws') || !cfg.get('referenceTestBucket')) {
-      console.log("Skipping 'publish', missing config file: " +
-                  "taskcluster-base-test.conf.json");
+      throw new Error("Skipping 'publish', missing config file: " +
+                      "taskcluster-base-test.conf.json");
       return;
     }
 

--- a/test/api/responsetimer_test.js
+++ b/test/api/responsetimer_test.js
@@ -17,8 +17,8 @@ suite("api/responsetimer", function() {
   });
 
   if (!cfg.get('influxdb:connectionString')) {
-    console.log("Skipping 'ResponseTimerTest', missing config file: " +
-                "taskcluster-base-test.conf.json");
+    throw new Error("Skipping 'ResponseTimerTest', missing config file: " +
+                    "taskcluster-base-test.conf.json");
     return;
   }
 

--- a/test/exchanges_publish_test.js
+++ b/test/exchanges_publish_test.js
@@ -1,0 +1,87 @@
+suite("Exchanges", function() {
+  var assert  = require('assert');
+  var base    = require('../');
+  var aws     = require('aws-sdk-promise');
+
+  test("publish", function() {
+    var cfg = base.config({
+      envs: [
+        'aws_accessKeyId',
+        'aws_secretAccessKey',
+        'aws_region',
+        'aws_apiVersion',
+        'referenceTestBucket'
+      ],
+      filename:               'taskcluster-base-test'
+    });
+
+    if (!cfg.get('aws') || !cfg.get('referenceTestBucket')) {
+      throw new Error("Skipping 'publish', missing config file: " +
+                      "taskcluster-base-test.conf.json");
+    }
+
+    // Create an exchanges
+    var exchanges = new base.Exchanges({
+      title:              "Title for my Events",
+      description:        "Test exchanges used for testing things only"
+    });
+    // Check that we can declare an exchange
+    exchanges.declare({
+      exchange:           'test-exchange',
+      name:               'testExchange',
+      title:              "Test Exchange",
+      description:        "Place we post message for **testing**.",
+      routingKey: [
+        {
+          name:           'testId',
+          summary:        "Identifier that we use for testing",
+          multipleWords:  false,
+          required:       true,
+          maxSize:        22
+        }, {
+          name:           'taskRoutingKey',
+          summary:        "Test specific routing-key: `test.key`",
+          multipleWords:  true,
+          required:       true,
+          maxSize:        128
+        }, {
+          name:           'state',
+          summary:        "State of something",
+          multipleWords:  false,
+          required:       false,
+          maxSize:        16
+        }
+      ],
+      schema: 'http://schemas.taskcluster.net/base/tests/exchanges-test.json',
+      messageBuilder:     function(test) { return test; },
+      routingKeyBuilder:  function(test, state) {
+        return {
+          testId:           test.id,
+          taskRoutingKey:   test.key,
+          state:            state
+        }
+      },
+      CCBuilder:          function() { return []; }
+    });
+
+    // Publish
+    return exchanges.publish({
+      referencePrefix:      'base/test/exchanges.json',
+      referenceBucket:      cfg.get('referenceTestBucket'),
+      aws:                  cfg.get('aws')
+    }).then(function() {
+      // Get the file... we don't bother checking the contents this is good
+      // enough
+      var s3 = new aws.S3(cfg.get('aws'));
+      return s3.getObject({
+        Bucket:     cfg.get('referenceTestBucket'),
+        Key:        'base/test/exchanges.json'
+      }).promise();
+    }).then(function(res) {
+      var reference = JSON.parse(res.data.Body);
+      assert(reference.entries, "Missing entries");
+      assert(reference.entries.length > 0, "Has no entries");
+      assert(reference.title, "Missing title");
+    });
+  });
+});

--- a/test/exchanges_test.js
+++ b/test/exchanges_test.js
@@ -1,7 +1,6 @@
 suite("Exchanges", function() {
   var assert  = require('assert');
   var base    = require('../');
-  var aws     = require('aws-sdk-promise');
   var debug   = require('debug')('base:test:exchanges');
 
   test("declare", function() {
@@ -248,89 +247,6 @@ suite("Exchanges", function() {
     });
 
     assert(reference.exchangePrefix === 'exchange/test-user/v1/');
-  });
-
-  test("publish", function() {
-    var cfg = base.config({
-      envs: [
-        'aws_accessKeyId',
-        'aws_secretAccessKey',
-        'aws_region',
-        'aws_apiVersion',
-        'referenceTestBucket'
-      ],
-      filename:               'taskcluster-base-test'
-    });
-
-    if (!cfg.get('aws') || !cfg.get('referenceTestBucket')) {
-      console.log("Skipping 'publish', missing config file: " +
-                  "taskcluster-base-test.conf.json");
-      return;
-    }
-
-    // Create an exchanges
-    var exchanges = new base.Exchanges({
-      title:              "Title for my Events",
-      description:        "Test exchanges used for testing things only"
-    });
-    // Check that we can declare an exchange
-    exchanges.declare({
-      exchange:           'test-exchange',
-      name:               'testExchange',
-      title:              "Test Exchange",
-      description:        "Place we post message for **testing**.",
-      routingKey: [
-        {
-          name:           'testId',
-          summary:        "Identifier that we use for testing",
-          multipleWords:  false,
-          required:       true,
-          maxSize:        22
-        }, {
-          name:           'taskRoutingKey',
-          summary:        "Test specific routing-key: `test.key`",
-          multipleWords:  true,
-          required:       true,
-          maxSize:        128
-        }, {
-          name:           'state',
-          summary:        "State of something",
-          multipleWords:  false,
-          required:       false,
-          maxSize:        16
-        }
-      ],
-      schema: 'http://schemas.taskcluster.net/base/tests/exchanges-test.json',
-      messageBuilder:     function(test) { return test; },
-      routingKeyBuilder:  function(test, state) {
-        return {
-          testId:           test.id,
-          taskRoutingKey:   test.key,
-          state:            state
-        }
-      },
-      CCBuilder:          function() { return []; }
-    });
-
-    // Publish
-    return exchanges.publish({
-      referencePrefix:      'base/test/exchanges.json',
-      referenceBucket:      cfg.get('referenceTestBucket'),
-      aws:                  cfg.get('aws')
-    }).then(function() {
-      // Get the file... we don't bother checking the contents this is good
-      // enough
-      var s3 = new aws.S3(cfg.get('aws'));
-      return s3.getObject({
-        Bucket:     cfg.get('referenceTestBucket'),
-        Key:        'base/test/exchanges.json'
-      }).promise();
-    }).then(function(res) {
-      var reference = JSON.parse(res.data.Body);
-      assert(reference.entries, "Missing entries");
-      assert(reference.entries.length > 0, "Has no entries");
-      assert(reference.title, "Missing title");
-    });
   });
 
   // Test that we can't declare too long routing keys

--- a/test/legacyentity_test.js
+++ b/test/legacyentity_test.js
@@ -21,10 +21,8 @@ suite("LegacyEntity", function() {
   if (!cfg.get('azureTestTableName') ||
       !cfg.get('azure') ||
       !cfg.get('influxdb:connectionString')) {
-    console.log("\nWARNING:");
-    console.log("Skipping 'entity' tests, missing config file: " +
-                "taskcluster-base-test.conf.json");
-    return;
+    throw new Error("Skipping 'entity' tests, missing config file: " +
+                    "taskcluster-base-test.conf.json");
   }
 
   // Configure an abstract Item to play with...

--- a/test/pulsepublisher_test.js
+++ b/test/pulsepublisher_test.js
@@ -18,8 +18,8 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   if (!cfg.get('influxdb:connectionString') &&
       !cfg.get('pulse:credentials:password')) {
-    console.log("Skipping 'pulse publisher', missing config file: " +
-                "taskcluster-base-test.conf.json");
+    throw new Error("Skipping 'pulse publisher', missing config file: " +
+                    "taskcluster-base-test.conf.json");
     return;
   }
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -1,40 +1,65 @@
-#!/bin/bash -ve
-# USAGE: Run this file using `npm test` (must run from repository root)
+#!/bin/bash -e
+# USAGE: Run this file using `npm test` or `npm run-script test-local`
+# (must run from repository root)
 
-mocha                                       \
-  test/entity/create_load_test.js           \
-  test/entity/context_test.js               \
-  test/entity/modify_test.js                \
-  test/entity/reload_test.js                \
-  test/entity/migration_definition_test.js  \
-  test/entity/query_test.js                 \
-  test/entity/remove_test.js                \
-  test/entity/constantkey_test.js           \
-  test/entity/compositekey_test.js          \
-  test/entity/hashkey_test.js               \
-  test/entity/datatypes_test.js             \
-  test/entity/blobtype_test.js              \
-  test/entity/jsontype_test.js              \
-  test/entity/slugidarray_test.js           \
-  test/entity/texttype_test.js              \
-  test/entity/sas_test.js                   \
-  test/entity/auth_test.js                  \
-  test/legacyentity_test.js                 \
-  test/config_test.js                       \
-  test/validator_test.js                    \
-  test/api/publish_test.js                  \
-  test/api/auth_test.js                     \
-  test/api/route_test.js                    \
-  test/api/validate_test.js                 \
-  test/api/noncemanager_test.js             \
-  test/api/responsetimer_test.js            \
-  test/app_test.js                          \
-  test/exchanges_test.js                    \
-  test/pulsepublisher_test.js               \
-  test/stats_test.js                        \
-  test/testing/pulsetestreceiver_test.js    \
-  test/testing/localapp_test.js             \
-  test/testing/localapp2_test.js            \
-  test/testing/schemas_test.js              \
-  test/testing/mockauthserver_test.js       \
-  ;
+case $1 in
+    local) local_only=true ;;
+    full) local_only=false ;;
+    *)
+        echo "Specify either 'local' or 'full'"
+        exit 1
+        ;;
+esac
+
+# tests that can run locally
+local_tests=(
+  test/config_test.js
+  test/validator_test.js
+  test/api/auth_test.js
+  test/api/route_test.js
+  test/api/validate_test.js
+  test/api/noncemanager_test.js
+  test/app_test.js
+  test/exchanges_test.js
+  test/testing/localapp_test.js
+  test/testing/localapp2_test.js
+  test/entity/migration_definition_test.js
+  test/testing/schemas_test.js
+)
+
+remote_tests=(
+  test/pulsepublisher_test.js
+  test/api/publish_test.js
+  test/exchanges_publish_test.js
+  test/api/responsetimer_test.js
+  test/testing/pulsetestreceiver_test.js
+  test/entity/create_load_test.js
+  test/entity/context_test.js
+  test/stats_test.js
+  test/entity/modify_test.js
+  test/entity/reload_test.js
+  test/testing/mockauthserver_test.js
+  test/entity/query_test.js
+  test/entity/remove_test.js
+  test/entity/constantkey_test.js
+  test/entity/compositekey_test.js
+  test/entity/hashkey_test.js
+  test/entity/datatypes_test.js
+  test/entity/blobtype_test.js
+  test/entity/jsontype_test.js
+  test/entity/slugidarray_test.js
+  test/entity/texttype_test.js
+  test/entity/sas_test.js
+  test/entity/auth_test.js
+  test/legacyentity_test.js
+  test/validator_publish_test.js
+)
+
+# tests that require external services and credentials
+if $local_only; then
+    tests=(${local_tests[@]})
+else
+    tests=(${remote_tests[@]} ${local_tests[@]})
+fi
+
+mocha ${tests[@]}

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -20,6 +20,7 @@ local_tests=(
   test/api/validate_test.js
   test/api/noncemanager_test.js
   test/app_test.js
+  test/scopematch_test.js
   test/exchanges_test.js
   test/testing/localapp_test.js
   test/testing/localapp2_test.js

--- a/test/scopematch_test.js
+++ b/test/scopematch_test.js
@@ -49,13 +49,13 @@ suite("scopeMatch", function() {
     mktest([], [['foo:bar']], false));
   test("bare star",
     mktest(["*"], [['foo:bar', 'bar:bing']], true));
+  test("empty conjunction in scopesets",
+    mktest(["foo:bar"], [[]], true));
   test("non-string scopesets",
     mktest(["foo:bar"], {}, 'exception'));
   test("non-string scopeset",
     mktest(["foo:bar"], [{}], 'exception'));
   test("empty disjunction in scopesets",
     mktest(["foo:bar"], [], false));
-  test("empty conjunction in scopesets",
-    mktest(["foo:bar"], [[]], 'exception'));
 });
 

--- a/test/scopematch_test.js
+++ b/test/scopematch_test.js
@@ -1,0 +1,61 @@
+suite("scopeMatch", function() {
+  var assert  = require('assert');
+  var utils   = require('../utils.js');
+
+  var mktest = function(scopePatterns, scopesets, matches) {
+    return function() {
+      var res;
+      try {
+        res = utils.scopeMatch(scopePatterns, scopesets);
+      } catch (e) {
+        res = 'exception';
+      }
+      assert(res == matches,
+        "Incorrect result for scopeMatch(" +
+        JSON.stringify(scopePatterns) +
+        ", " + JSON.stringify(scopesets) + ")")
+    };
+  };
+
+  test("single exact match, string",
+    mktest(["foo:bar"], "foo:bar", true));
+  test("single exact match, [string]",
+    mktest(["foo:bar"], ["foo:bar"], true));
+  test("single exact match, [[string]]",
+    mktest(["foo:bar"], [["foo:bar"]], true));
+  test("empty string in scopesets",
+    mktest(["foo:bar"], '', false));
+  test("empty [string] in scopesets",
+    mktest(["foo:bar"], [''], false));
+  test("empty [[string]] in scopesets",
+    mktest(["foo:bar"], [['']], false));
+  test("prefix",
+    mktest(["foo:*"], [['foo:bar']], true));
+  test("prefix with no star",
+    mktest(["foo:"], [['foo:bar']], false));
+  test("star but not prefix",
+    mktest(["foo:bar:*"], [['bar:bing']], false));
+  test("star but not prefix",
+    mktest(["bar:*"], [['foo:bar:bing']], false));
+  test("disjunction strings",
+    mktest(["bar:*"], ['foo:x', 'bar:x'], true));
+  test("disjunction [strings]",
+    mktest(["bar:*"], [['foo:x'], ['bar:x']], true));
+  test("conjunction",
+    mktest(["bar:*", 'foo:x'], [['foo:x', 'bar:y']], true));
+  test("empty pattern",
+    mktest([""], [['foo:bar']], false));
+  test("empty patterns",
+    mktest([], [['foo:bar']], false));
+  test("bare star",
+    mktest(["*"], [['foo:bar', 'bar:bing']], true));
+  test("non-string scopesets",
+    mktest(["foo:bar"], {}, 'exception'));
+  test("non-string scopeset",
+    mktest(["foo:bar"], [{}], 'exception'));
+  test("empty disjunction in scopesets",
+    mktest(["foo:bar"], [], false));
+  test("empty conjunction in scopesets",
+    mktest(["foo:bar"], [[]], 'exception'));
+});
+

--- a/test/stats_test.js
+++ b/test/stats_test.js
@@ -14,8 +14,8 @@ suite('stats', function() {
   });
 
   if (!cfg.get('influxdb:connectionString')) {
-    console.log("Skipping 'stats', missing config file: " +
-                "taskcluster-base-test.conf.json");
+    throw new Error("Skipping 'stats', missing config file: " +
+                    "taskcluster-base-test.conf.json");
     return;
   }
 

--- a/test/testing/pulsetestreceiver_test.js
+++ b/test/testing/pulsetestreceiver_test.js
@@ -15,8 +15,8 @@ suite('testing.PulseTestReceiver', function() {
 
   // Validate that we have needed config
   if (!cfg.get('influxdb:connectionString')) {
-    console.log("Skipping 'testing.Events' test, missing config file: " +
-                "taskcluster-base-test.conf.json");
+    throw new Error("Skipping 'testing.Events' test, missing config file: " +
+                    "taskcluster-base-test.conf.json");
     return;
   }
 

--- a/test/validator_publish_test.js
+++ b/test/validator_publish_test.js
@@ -1,0 +1,58 @@
+suite("validator", function() {
+  var assert  = require('assert');
+  var path    = require('path');
+  var aws     = require('aws-sdk-promise');
+  var base    = require('../');
+  var http    = require('http');
+
+
+  test("test publish", function() {
+    var cfg = base.config({
+      envs: [
+        'aws_accessKeyId',
+        'aws_secretAccessKey',
+        'aws_region',
+        'aws_apiVersion',
+        'schemaTestBucket'
+      ],
+      filename:               'taskcluster-base-test'
+    });
+
+    if (!cfg.get('aws') || !cfg.get('schemaTestBucket')) {
+      throw new Error("Skipping 'publish', missing config file: " +
+                      "taskcluster-base-test.conf.json");
+    }
+
+    return base.validator({
+      publish:      true,
+      schemaPrefix: 'base/test/',
+      schemaBucket: cfg.get('schemaTestBucket'),
+      aws:          cfg.get('aws'),
+      folder:       path.join(__dirname, 'schemas'),
+      constants:    {"my-constant": 42}
+    }).then(function(validator) {
+      var errors = validator.check({
+        value: 42
+      }, 'http://localhost:1203/test-schema.json');
+      assert(errors === null, "Got errors");
+
+      // Get the file... we don't bother checking the contents this is good
+      // enough
+      var s3 = new aws.S3(cfg.get('aws'));
+      return s3.getObject({
+        Bucket:     cfg.get('schemaTestBucket'),
+        Key:        'base/test/test-schema.json'
+      }).promise().then(function() {
+        return s3.getObject({
+          Bucket:     cfg.get('schemaTestBucket'),
+          Key:        'base/test/yaml-test-schema.json'
+        }).promise();
+      }).then(function() {
+        return s3.getObject({
+          Bucket:     cfg.get('schemaTestBucket'),
+          Key:        'base/test/yml-test-schema.json'
+        }).promise();
+      });
+    });
+  });
+});

--- a/test/validator_test.js
+++ b/test/validator_test.js
@@ -1,7 +1,6 @@
 suite("validator", function() {
   var assert  = require('assert');
   var path    = require('path');
-  var aws     = require('aws-sdk-promise');
   var base    = require('../');
   var express = require('express');
   var http    = require('http');
@@ -228,53 +227,4 @@ suite("validator", function() {
     });
   });
 
-  test("test publish", function() {
-    var cfg = base.config({
-      envs: [
-        'aws_accessKeyId',
-        'aws_secretAccessKey',
-        'aws_region',
-        'aws_apiVersion',
-        'schemaTestBucket'
-      ],
-      filename:               'taskcluster-base-test'
-    });
-
-    if (cfg.get('aws') && cfg.get('schemaTestBucket')) {
-      return base.validator({
-        publish:      true,
-        schemaPrefix: 'base/test/',
-        schemaBucket: cfg.get('schemaTestBucket'),
-        aws:          cfg.get('aws'),
-        folder:       path.join(__dirname, 'schemas'),
-        constants:    {"my-constant": 42}
-      }).then(function(validator) {
-        var errors = validator.check({
-          value: 42
-        }, 'http://localhost:1203/test-schema.json');
-        assert(errors === null, "Got errors");
-
-        // Get the file... we don't bother checking the contents this is good
-        // enough
-        var s3 = new aws.S3(cfg.get('aws'));
-        return s3.getObject({
-          Bucket:     cfg.get('schemaTestBucket'),
-          Key:        'base/test/test-schema.json'
-        }).promise().then(function() {
-          return s3.getObject({
-            Bucket:     cfg.get('schemaTestBucket'),
-            Key:        'base/test/yaml-test-schema.json'
-          }).promise();
-        }).then(function() {
-          return s3.getObject({
-            Bucket:     cfg.get('schemaTestBucket'),
-            Key:        'base/test/yml-test-schema.json'
-          }).promise();
-        });
-      });
-    } else {
-      console.log("Skipping 'publish', missing config file: " +
-                  "taskcluster-base-test.conf.json");
-    }
-  });
 });

--- a/utils.js
+++ b/utils.js
@@ -61,7 +61,6 @@ exports.scopeMatch = function(scopePatterns, scopesets) {
   assert(scopesets instanceof Array, "scopesets must be a string or an array");
   return scopesets.some(function(scopeset) {
     assert(scopesets instanceof Array, "scopeset must be a string or an array");
-    assert(scopeset.length > 0, "scopeset must have at least one element");
     return scopeset.every(function(scope) {
       return scopePatterns.some(function(pattern) {
         if (scope === pattern) {

--- a/utils.js
+++ b/utils.js
@@ -61,6 +61,7 @@ exports.scopeMatch = function(scopePatterns, scopesets) {
   assert(scopesets instanceof Array, "scopesets must be a string or an array");
   return scopesets.some(function(scopeset) {
     assert(scopesets instanceof Array, "scopeset must be a string or an array");
+    assert(scopeset.length > 0, "scopeset must have at least one element");
     return scopeset.every(function(scope) {
       return scopePatterns.some(function(pattern) {
         if (scope === pattern) {


### PR DESCRIPTION
The tests all pass, except the scopeset `[[]]` is always true, which is probably not what you want.

I'm still a little worried about the visual similarity of
```
    scopes: ["auth:foo", "auth:bar"],
```
```
    scopes: [["auth:foo", "auth:bar"]],
```
Particularly since I doubt this would be caught by relatively scant unit testing (which would, at best, confirm that the API action is forbidden with no scopes and allowed with both scopes, not noticing that in the former case it's also allowed with *either* scope).

I'm tempted to get rid of the normalization (which converts the former to the much-more-obviously-wrong `[["auth:foo"], ["auth:bar"]]`) in API definitions.  The idea is to make it hard to introduce a subtle error with severe consequences.

Note that this PR depends on #18.  Neither runs correctly in Travis due to the lack of OpenSSL keys, so please ignore the red X's.