### PR TITLE
Bug 1177490

### DIFF
--- a/exchanges.js
+++ b/exchanges.js
@@ -157,7 +157,8 @@ Publisher.prototype.close = function() {
  * {
  *   title:              "Title of documentation page",
  *   description:        "Description in markdown",
- *   exchangePrefix:     'prefix/'     // For all exchanges declared here
+ *   exchangePrefix:     'prefix/'            // For all exchanges declared here
+ *   schemaPrefix:       "http://schemas...", // Prefix for all schemas
  *   durableExchanges:   true || false // If exchanges are durable
  * }
  *
@@ -169,7 +170,8 @@ var Exchanges = function(options) {
   this._entries = [];
   this._options = {
     exchangePrefix:       '',
-    durableExchanges:     true
+    durableExchanges:     true,
+    schemaPrefix:         ''
   };
   assert(options.title,       "title must be provided");
   assert(options.description, "description must be provided");
@@ -226,6 +228,11 @@ Exchanges.prototype.declare = function(options) {
     assert(typeof(options[key]) === 'string', "Option: '" + key + "' must be " +
            "a string");
   });
+
+  // Prefix schemas if a prefix is declared
+  if (this._options.schemaPrefix) {
+    options.schema = this._options.schemaPrefix + options.schema;
+  }
 
   // Validate routingKey declaration
   assert(options.routingKey instanceof Array,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "taskcluster-base",
-  "version":      "0.7.29",
+  "version":      "0.8.0",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Common modules for taskcluster components",
   "license":      "MPL-2.0",

--- a/test/api/schemaprefix_test.js
+++ b/test/api/schemaprefix_test.js
@@ -1,4 +1,4 @@
-suite("api/validate", function() {
+suite("api/schemaPrefix", function() {
   require('superagent-hawk')(require('superagent'));
   var request         = require('superagent-promise');
   var assert          = require('assert');
@@ -8,11 +8,11 @@ suite("api/validate", function() {
   var express         = require('express');
   var path            = require('path');
 
-
   // Create test api
   var api = new base.API({
     title:        "Test Api",
-    description:  "Another test api"
+    description:  "Another test api",
+    schemaPrefix: 'http://localhost:4321/'
   });
 
   // Declare a method we can test input with
@@ -20,7 +20,7 @@ suite("api/validate", function() {
     method:   'get',
     route:    '/test-input',
     name:     'testInput',
-    input:    'http://localhost:4321/test-schema.json',
+    input:    'test-schema.json',
     title:    "Test End-Point",
     description:  "Place we can call to test something",
   }, function(req, res) {
@@ -32,49 +32,11 @@ suite("api/validate", function() {
     method:   'get',
     route:    '/test-output',
     name:     'testInput',
-    output:   'http://localhost:4321/test-schema.json',
+    output:   'test-schema.json',
     title:    "Test End-Point",
     description:  "Place we can call to test something",
   }, function(req, res) {
     res.reply({value: 4});
-  });
-
-  // Declare a method we can use to test invalid output
-  api.declare({
-    method:   'get',
-    route:    '/test-invalid-output',
-    name:     'testInput',
-    output:   'http://localhost:4321/test-schema.json',
-    title:    "Test End-Point",
-    description:  "Place we can call to test something",
-  }, function(req, res) {
-    res.reply({value: 12});
-  });
-
-  // Declare a method we can test input validation skipping on
-  api.declare({
-    method:   'get',
-    route:    '/test-skip-input-validation',
-    name:     'testInputSkipInputValidation',
-    input:    'http://localhost:4321/test-schema.json',
-    skipInputValidation: true,
-    title:    "Test End-Point",
-    description:  "Place we can call to test something",
-  }, function(req, res) {
-    res.status(200).send("Hello World");
-  });
-
-  // Declare a method we can test output validation skipping on
-  api.declare({
-    method:   'get',
-    route:    '/test-skip-output-validation',
-    name:     'testOutputSkipInputValidation',
-    output:    'http://localhost:4321/test-schema.json',
-    skipOutputValidation: true,
-    title:    "Test End-Point",
-    description:  "Place we can call to test something",
-  }, function(req, res) {
-    res.reply({value: 12});
   });
 
   // Reference to mock authentication server
@@ -182,42 +144,6 @@ suite("api/validate", function() {
       .then(function(res) {
         assert(res.ok, "Request okay");
         assert(res.body.value === 4, "Got wrong value");
-      });
-  });
-
-  // test invalid output
-  test("output (invalid)", function() {
-    var url = 'http://localhost:61515/test-invalid-output';
-    return request
-      .get(url)
-      .end()
-      .then(function(res) {
-        assert(res.status === 500, "Request wasn't 500");
-      });
-  });
-
-  // test skipping input validation
-  test("skip input validation", function() {
-    var url = 'http://localhost:61515/test-skip-input-validation';
-    return request
-      .get(url)
-      .send({value: 100})
-      .end()
-      .then(function(res) {
-        assert(res.ok, "Request failed");
-        assert(res.text === "Hello World", "Got wrong value");
-      });
-  });
-
-  // test skipping output validation
-  test("skip output validation", function() {
-    var url = 'http://localhost:61515/test-skip-output-validation';
-    return request
-      .get(url)
-      .end()
-      .then(function(res) {
-        assert(res.ok, "Request failed");
-        assert(res.body.value === 12, "Got wrong value");
       });
   });
 });

--- a/test/api/schemas/test-schema.json
+++ b/test/api/schemas/test-schema.json
@@ -1,5 +1,5 @@
 {
-  "id":           "http://localhost:4321/test-schema.json",
+  "id":           "http://localhost:4321/test-schema.json#",
   "$schema":      "http://json-schema.org/draft-04/schema#",
   "title":        "test schema",
   "type":         "object",

--- a/test/publish-schemas/auto-named-schema.yml
+++ b/test/publish-schemas/auto-named-schema.yml
@@ -1,0 +1,11 @@
+$schema:        http://json-schema.org/draft-04/schema#
+title:          "Automatically named schema, based on filename"
+type:           object
+properties:
+  value:
+    type:       integer
+    minimum:    {$const: my-constant}
+    maximum:    {$const: my-constant}
+additionalProperties: false
+required:
+  - value

--- a/test/publish-schemas/test-schema.json
+++ b/test/publish-schemas/test-schema.json
@@ -1,0 +1,15 @@
+{
+  "id":           "http://localhost:1203/base/test/test-schema.json#",
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "test json schema",
+  "type":         "object",
+  "properties": {
+    "value": {
+      "type":           "integer",
+      "minimum":        {"$const": "my-constant"},
+      "maximum":        {"$const": "my-constant"}
+    }
+  },
+  "additionalProperties":   false,
+  "required": ["value"]
+}

--- a/test/publish-schemas/yaml-test-schema.yaml
+++ b/test/publish-schemas/yaml-test-schema.yaml
@@ -1,0 +1,12 @@
+id:             http://localhost:1203/base/test/yaml-test-schema.json#
+$schema:        http://json-schema.org/draft-04/schema#
+title:          "test json schema"
+type:           object
+properties:
+  value:
+    type:       integer
+    minimum:    {$const: my-constant}
+    maximum:    {$const: my-constant}
+additionalProperties: false
+required:
+  - value

--- a/test/publish-schemas/yml-test-schema.yml
+++ b/test/publish-schemas/yml-test-schema.yml
@@ -1,0 +1,12 @@
+id:             http://localhost:1203/base/test/yml-test-schema.json#
+$schema:        http://json-schema.org/draft-04/schema#
+title:          "test json schema"
+type:           object
+properties:
+  value:
+    type:       integer
+    minimum:    {$const: my-constant}
+    maximum:    {$const: my-constant}
+additionalProperties: false
+required:
+  - value

--- a/test/pulsepublisherschemaprefix_test.js
+++ b/test/pulsepublisherschemaprefix_test.js
@@ -1,0 +1,125 @@
+suite("Exchanges (Publish on Pulse w. schemaPrefix)", function() {
+  var assert  = require('assert');
+  var base    = require('../');
+  var path    = require('path');
+  var fs      = require('fs');
+  var debug   = require('debug')('base:test:publish-pulse');
+  var Promise = require('promise');
+  var slugid  = require('slugid');
+  var amqplib  = require('amqplib');
+
+  // Load necessary configuration
+  var cfg = base.config({
+    envs: [
+      'influxdb_connectionString',
+    ],
+    filename:               'taskcluster-base-test'
+  });
+
+  if (!cfg.get('influxdb:connectionString') &&
+      !cfg.get('pulse:credentials:password')) {
+    throw new Error("Skipping 'pulse publisher', missing config file: " +
+                    "taskcluster-base-test.conf.json");
+    return;
+  }
+
+  // ConnectionString for use with amqplib only
+  var connectionString = [
+    'amqps://',         // Ensure that we're using SSL
+    cfg.get('pulse:username'),
+    ':',
+    cfg.get('pulse:password'),
+    '@',
+    cfg.get('pulse:hostname') || 'pulse.mozilla.org',
+    ':',
+    5671                // Port for SSL
+  ].join('');
+
+  var influx = null;
+  var exchanges = null;
+  setup(function() {
+    exchanges = new base.Exchanges({
+      title:              "Title for my Events",
+      description:        "Test exchanges used for testing things only",
+      schemaPrefix:       'http://localhost:1203/'
+    });
+    // Check that we can declare an exchange
+    exchanges.declare({
+      exchange:           'test-exchange',
+      name:               'testExchange',
+      title:              "Test Exchange",
+      description:        "Place we post message for **testing**.",
+      routingKey: [
+        {
+          name:           'testId',
+          summary:        "Identifier that we use for testing",
+          multipleWords:  false,
+          required:       true,
+          maxSize:        22
+        }, {
+          name:           'taskRoutingKey',
+          summary:        "Test specific routing-key: `test.key`",
+          multipleWords:  true,
+          required:       true,
+          maxSize:        128
+        }, {
+          name:           'state',
+          summary:        "State of something",
+          multipleWords:  false,
+          required:       false,
+          maxSize:        16
+        }, {
+          name:           'index',
+          summary:        "index of something",
+          multipleWords:  false,
+          required:       false,
+          maxSize:        3
+        }, {
+          name:           'myConstant',
+          summary:        "Some constant to test",
+          constant:       "-constant-"
+        }
+      ],
+      schema:             'exchange-test-schema.json#',
+      messageBuilder:     function(msg) { return msg; },
+      routingKeyBuilder:  function(msg, rk) { return rk; },
+      CCBuilder:          function() {return ["something.cced"];}
+    });
+    // Create validator to validate schema
+    var validator = new base.validator.Validator();
+    // Load exchange-test-schema.json schema from disk
+    var schemaPath = path.join(__dirname, 'schemas', 'exchange-test-schema.json');
+    var schema = fs.readFileSync(schemaPath, {encoding: 'utf-8'});
+    validator.register(JSON.parse(schema));
+
+    // Create influx db connection for report statistics
+    influx = new base.stats.Influx({
+      connectionString:   cfg.get('influxdb:connectionString')
+    });
+
+    // Set options on exchanges
+    exchanges.configure({
+      validator:              validator,
+      credentials:            cfg.get('pulse')
+    });
+  });
+
+  // Test that we can connect to AMQP server
+  test("connect", function() {
+    return exchanges.connect().then(function(publisher) {
+      assert(publisher instanceof base.Exchanges.Publisher,
+             "Should get an instance of base.Exchanges.Publisher");
+    });
+  });
+
+  // Test that we can publish messages
+  test("publish message", function() {
+    return exchanges.connect().then(function(publisher) {
+      return publisher.testExchange({someString: "My message"}, {
+        testId:           "myid",
+        taskRoutingKey:   "some.string.with.dots",
+        state:            undefined // Optional
+      });
+    });
+  });
+});

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -18,6 +18,7 @@ local_tests=(
   test/api/auth_test.js
   test/api/route_test.js
   test/api/validate_test.js
+  test/api/schemaprefix_test.js
   test/api/noncemanager_test.js
   test/app_test.js
   test/scopematch_test.js
@@ -30,6 +31,7 @@ local_tests=(
 
 remote_tests=(
   test/pulsepublisher_test.js
+  test/pulsepublisherschemaprefix_test.js
   test/api/publish_test.js
   test/exchanges_publish_test.js
   test/api/responsetimer_test.js

--- a/test/schemas/auto-named-schema.yml
+++ b/test/schemas/auto-named-schema.yml
@@ -1,0 +1,11 @@
+$schema:        http://json-schema.org/draft-04/schema#
+title:          "Automatically named schema, based on filename"
+type:           object
+properties:
+  value:
+    type:       integer
+    minimum:    {$const: my-constant}
+    maximum:    {$const: my-constant}
+additionalProperties: false
+required:
+  - value

--- a/test/testing/schemas_test.js
+++ b/test/testing/schemas_test.js
@@ -3,7 +3,8 @@ suite('testing.schema', function() {
   var path  = require('path');
   base.testing.schemas({
     validator: {
-      folder:     path.join(__dirname, 'schemas'),
+      folder:         path.join(__dirname, 'schemas'),
+      schemaBaseUrl:  'http://localhost:1234/'
     },
     cases: [
       {
@@ -25,7 +26,8 @@ suite('testing.schema w. schemaPrefix', function() {
   var path  = require('path');
   base.testing.schemas({
     validator: {
-      folder:     path.join(__dirname, 'schemas'),
+      folder:         path.join(__dirname, 'schemas'),
+      schemaBaseUrl:  'http://localhost:1234/'
     },
     cases: [
       {

--- a/test/validator_publish_test.js
+++ b/test/validator_publish_test.js
@@ -24,16 +24,21 @@ suite("validator", function() {
     }
 
     return base.validator({
-      publish:      true,
-      schemaPrefix: 'base/test/',
-      schemaBucket: cfg.get('schemaTestBucket'),
-      aws:          cfg.get('aws'),
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
+      publish:        true,
+      schemaPrefix:   'base/test/',
+      schemaBucket:   cfg.get('schemaTestBucket'),
+      aws:            cfg.get('aws'),
+      folder:         path.join(__dirname, 'publish-schemas'),
+      constants:      {"my-constant": 42},
+      schemaBaseUrl:  'http://localhost:1203/'
     }).then(function(validator) {
       var errors = validator.check({
         value: 42
-      }, 'http://localhost:1203/test-schema.json');
+      }, 'http://localhost:1203/base/test/test-schema.json');
+      assert(errors === null, "Got errors");
+      var errors = validator.check({
+        value: 42
+      }, 'http://localhost:1203/base/test/auto-named-schema.json');
       assert(errors === null, "Got errors");
 
       // Get the file... we don't bother checking the contents this is good

--- a/test/validator_test.js
+++ b/test/validator_test.js
@@ -8,13 +8,17 @@ suite("validator", function() {
   var Promise = require('promise');
   var debug   = require('debug')('test:validator');
 
+  // Common options for loading schemas in all tests
+  var opts = {
+    publish:        false,
+    folder:         path.join(__dirname, 'schemas'),
+    constants:      {"my-constant": 42},
+    schemaBaseUrl:  'http://localhost:1203/'
+  };
+
   // Test that we can load from a folder
   test("load from folder (json)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var errors = validator.check({
         value: 42
       }, 'http://localhost:1203/test-schema.json');
@@ -29,9 +33,10 @@ suite("validator", function() {
   test("load from folder (invalid schema -> error)", function() {
     try {
       base.validator({
-        publish:      false,
-        folder:       path.join(__dirname, 'invalid-schemas'),
-        constants:    {"my-constant": 42}
+        publish:        false,
+        folder:         path.join(__dirname, 'invalid-schemas'),
+        constants:      {"my-constant": 42},
+        schemaBaseUrl:  'http://localhost:1203/'
       });
       assert(false, "Expected an error");
     } catch (err) {
@@ -41,11 +46,7 @@ suite("validator", function() {
   });
 
   test("test $ref", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var errors = validator.check({
         reference: {
           value: 42
@@ -61,11 +62,7 @@ suite("validator", function() {
   });
 
   test("test default values (no key provided)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var json = {
         value: 42
       };
@@ -85,11 +82,7 @@ suite("validator", function() {
   });
 
   test("test default values (value provided)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var json = {
         value: 42,
         optionalValue: "procided-value"
@@ -110,11 +103,7 @@ suite("validator", function() {
   });
 
   test("test default values (array and object)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var json = {};
       var errors = validator.check(
         json,
@@ -134,11 +123,7 @@ suite("validator", function() {
   });
 
   test("load from folder (yml)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var errors = validator.check({
         value: 42
       }, 'http://localhost:1203/yml-test-schema.json');
@@ -151,11 +136,7 @@ suite("validator", function() {
   });
 
   test("load from folder (yaml)", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var errors = validator.check({
         value: 42
       }, 'http://localhost:1203/yaml-test-schema.json');
@@ -215,11 +196,7 @@ suite("validator", function() {
   });
 
   test("find errors", function() {
-    return base.validator({
-      publish:      false,
-      folder:       path.join(__dirname, 'schemas'),
-      constants:    {"my-constant": 42}
-    }).then(function(validator) {
+    return base.validator(opts).then(function(validator) {
       var errors = validator.check({
         value: 43
       }, 'http://localhost:1203/test-schema.json');
@@ -227,4 +204,21 @@ suite("validator", function() {
     });
   });
 
+  test("can validate", function() {
+    return base.validator(opts).then(function(validator) {
+      var errors = validator.check({
+        value: 42
+      }, 'http://localhost:1203/test-schema.json');
+      assert(errors === null, "Got errors");
+    });
+  });
+
+  test("automatically set schema.id", function() {
+    return base.validator(opts).then(function(validator) {
+      var errors = validator.check({
+        value: 42
+      }, 'http://localhost:1203/auto-named-schema.json');
+      assert(errors === null, "Got errors");
+    });
+  });
 });

--- a/validator.js
+++ b/validator.js
@@ -10,6 +10,7 @@ var Promise     = require('promise');
 var assert      = require('assert');
 var path        = require('path');
 var yaml        = require('js-yaml');
+var urljoin     = require('url-join');
 
 var utils       = require('./utils');
 
@@ -119,6 +120,7 @@ Validator.prototype.register = function(schema) {
  *   publish:           true,                     // Publish schemas from folder
  *   schemaPrefix:      'queue/v1/'               // Prefix within S3 bucket
  *   schemaBucket:      'schemas.taskcluster.net',// Schema publication bucket
+ *   schemaBaseUrl:     'http://schemas.t..c.net',// Schema baseUrl
  *   aws: {             // AWS credentials and region for schemaBucket
  *    accessKeyId:        '...',
  *    secretAccessKey:    '...',
@@ -130,7 +132,8 @@ Validator.prototype.register = function(schema) {
 var validator = function(options) {
   // Provide default options
   options = _.defaults(options || {}, {
-    schemaBucket:    'schemas.taskcluster.net'
+    schemaBucket:     'schemas.taskcluster.net',
+    schemaBaseUrl:    'schemas.taskcluster.net'
   });
 
   // Create validator
@@ -191,14 +194,35 @@ var validator = function(options) {
           throw err;
         }
 
-        // Register with the validator
-        validator.register(schema);
-
         // Find relative path and use it as name
         var name = path.relative(options.folder, filePath);
 
         // Replace .yaml and .yml with .json
         name = name.replace(/\.ya?ml$/, '.json');
+
+        // Determine schema id
+        var id = urljoin(
+          options.schemaBaseUrl,
+          options.schemaPrefix,
+          name
+        ) + '#';
+
+        // Add schema id, if already present
+        if (!schema.id) {
+          schema.id = id;
+        }
+
+        // Validate schema id, if set manually
+        if (schema.id !== id) {
+          debug("Bad schema name: %s expected: %s", schema.id, id);
+          throw new Error(
+            "Wrong schemaId: " + schema.id + " expected: " + id +
+            ", notice you don't have to specify one! We will set it for you!"
+          );
+        }
+
+        // Register with the validator
+        validator.register(schema);
 
         // Log that we loaded schema
         debug("Loaded: %s", filePath);

--- a/validator.js
+++ b/validator.js
@@ -72,7 +72,8 @@ var Validator = function(schemas) {
   });
 };
 
-/** Validate a JSON object given a schema identifier
+/**
+ * Validate a JSON object given a schema identifier
  * return null if there is no errors and list of errors if we have errors.
  *
  * For a decent introduction to JSON schemas see:


### PR DESCRIPTION
  * Validator now requires the option `schemaBaseUrl` **breaking change**
  * API now takes an option `schemaPrefix`
  * Exchanges now takes an option `schemaPrefix`

If `schema.id` is defined, validator will require that the id is correct. If no id is specified validator will specify one generated from `schemaBaseUrl + schemaPrefix + filename + ".json#"`.

Ideally, we should just stop specifying `schema.id`, but for now I have no problem allowing it as long as it matches whatever would be auto-generated. This way `schemaBaseUrl` is the only real breaking change at this point.