### PR TITLE
Param patterns

### DIFF
--- a/api.js
+++ b/api.js
@@ -42,7 +42,7 @@ var parameterValidator = function(options) {
            "Pattern given for param: '" + param + "' must be a RegExp or " +
            "a function");
   });
-  return function(req, res) {
+  return function(req, res, next) {
     var errors = [];
     _.forIn(req.params, function(val, param) {
       var pattern = options[param];
@@ -57,7 +57,7 @@ var parameterValidator = function(options) {
         var msg = pattern(val);
         if (typeof(msg) === 'string') {
           errors.push(
-            "URL parameter '" + param "' given  as '" + val +  "' is not " +
+            "URL parameter '" + param + "' given  as '" + val +  "' is not " +
             "valid: " + msg
           );
         }


### PR DESCRIPTION
After this we have the option of specify:
```js
var api = new base.API({
  ...,
  params: {
    taskId:     /^[a-zA-Z0-9-_]{22}$/,
    workerType: /^[a-zA-Z0-9-_]{1,22}$/
  }
});
```
Then whenever we have `:taskId` in a route it'll be validated against the regular expresison...
The same for `:workerType`.. So far we've mostly let these errors be 500 or cause weird behaviour... This is bad. As more people start using taskcluster we better lock this down too..

This will make it very easy to fix bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1088963

For anyone in doubt we often use two patterns:
 1. Slug ids, these must match: `/^[a-zA-Z0-9-_]{22}$/`
 2. Ids of other types we often allow: `/^[a-zA-Z0-9-_]{1,22}$/`  (`workerType`, `provisionerId`, `workerId`, workerGroupId` and a lot of other things in the future).

So far we've found that (1) and (2) serves us well, (1) offering short UUIDs and (2) offering short ids we can easily embed in RabbitMQ routing keys etc... So keeping this pattern is powerful.