### PR TITLE
Remote Signature validation

### DIFF
--- a/api.js
+++ b/api.js
@@ -21,6 +21,7 @@ var hoek          = require('hoek');
 var series        = require('./lib/series');
 var http          = require('http');
 var https         = require('https');
+var cryptiles     = require('cryptiles');
 
 // Default baseUrl for authentication server
 var AUTH_BASE_URL = 'https://auth.taskcluster.net/v1';
@@ -260,7 +261,8 @@ Client.prototype.limit = function(ext) {
       .digest('base64');
 
     // Validate signature
-    if (typeof(cert.signature) !== 'string' || cert.signature !== signature) {
+    if (typeof(cert.signature) !== 'string' ||
+        !cryptiles.fixedTimeComparison(cert.signature, signature)){
       throw new Error("ext.certificate.signature is not valid");
     }
 
@@ -807,7 +809,8 @@ var limitClientWithExt = function(client, ext) {
       .digest('base64');
 
     // Validate signature
-    if (typeof(cert.signature) !== 'string' || cert.signature !== signature) {
+    if (typeof(cert.signature) !== 'string' ||
+        !cryptiles.fixedTimeComparison(cert.signature, signature)) {
       throw new Error("ext.certificate.signature is not valid");
     }
 

--- a/api.js
+++ b/api.js
@@ -872,7 +872,7 @@ var limitClientWithExt = function(client, ext) {
  * The method returned by this function works as `signatureValidator` for
  * `remoteAuthentication`.
  */
-var makeSignatureValidator = function(options) {
+var createSignatureValidator = function(options) {
   assert(options.clientLoader instanceof Function,
          "options.clientLoader must be a function");
   var loadCredentials = function(clientId, ext, callback) {
@@ -998,7 +998,7 @@ var makeSignatureValidator = function(options) {
  * The method returned by this function works as `signatureValidator` for
  * `remoteAuthentication`.
  */
-var makeRemoteSignatureValidator = function(options) {
+var createRemoteSignatureValidator = function(options) {
   assert(options.authBaseUrl, "options.authBaseUrl is required");
   return function(data) {
     return request
@@ -1332,7 +1332,7 @@ API.prototype.router = function(options) {
     allowedCORSOrigin:    '*',
     context:              {},
     nonceManager:         nonceManager(),
-    signatureValidator:   makeRemoteSignatureValidator({
+    signatureValidator:   createRemoteSignatureValidator({
       authBaseUrl:        options.authBaseUrl || AUTH_BASE_URL
     })
   });
@@ -1595,4 +1595,4 @@ API.authenticate  = authenticate;
 API.schema        = schema;
 API.handle        = handle;
 API.stability     = stability;
-API.makeSignatureValidator = makeSignatureValidator;
+API.createSignatureValidator = createSignatureValidator;

--- a/api.js
+++ b/api.js
@@ -955,7 +955,7 @@ var createSignatureValidator = function(options) {
       } else {
       // If there is no authorization header we'll attempt a login with bewit
         hawk.uri.authenticate({
-          method:           req.method,
+          method:           req.method.toUpperCase(),
           url:              req.resource,
           host:             req.host,
           port:             req.port,
@@ -964,7 +964,9 @@ var createSignatureValidator = function(options) {
           var ext = undefined;
 
           // Get bewit string (stolen from hawk)
-          var parts = req.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/)
+          var parts = req.resource.match(
+            /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/
+          );
           var bewitString = hoek.base64urlDecode(parts[3]);
           if (!(bewitString instanceof Error)) {
             // Split string as hawk does it

--- a/api.js
+++ b/api.js
@@ -1110,7 +1110,7 @@ var remoteAuthentication = function(options, entry) {
       };
 
       // If authentication is deferred or satisfied, then we proceed
-      if (entry.deferAuth || req.satisfies(entry.scopes)) {
+      if (!entry.scopes || entry.deferAuth || req.satisfies(entry.scopes)) {
         next();
       }
     }).catch(function(err) {

--- a/api.js
+++ b/api.js
@@ -789,7 +789,7 @@ var limitClientWithExt = function(client, ext) {
     }
 
     // Validate certificate scopes are subset of client
-    if (!utils.scopeMatch(client.scopes, scopesets)) {
+    if (!utils.scopeMatch(client.scopes, [cert.scopes])) {
       throw new Error("ext.certificate issuer doesn't have sufficient scopes");
     }
 

--- a/api.js
+++ b/api.js
@@ -1011,7 +1011,7 @@ var createRemoteSignatureValidator = function(options) {
       maxSockets: 50
     });
   } else {
-    agent = new https.Agent({
+    agent = new http.Agent({
       keepAlive:  true,
       maxSockets: 50
     });

--- a/api.js
+++ b/api.js
@@ -1021,8 +1021,7 @@ var createRemoteSignatureValidator = function(options) {
       .post(options.authBaseUrl + '/authenticate-hawk')
       .agent(agent)
       .type('json')
-      //TODO: Make sure that we use a HTTP agent for this!!!
-      //      Just use TC-client when we have auth.tc.net deployed...
+      //TODO: Use TC-client when we have auth.tc.net deployed...
       //      So we get both retries and decent agent implementation
       .send(data)
       .end()

--- a/api.js
+++ b/api.js
@@ -907,7 +907,7 @@ var makeSignatureValidator = function(options) {
           }
           return accept({
             error:    true,
-            message:  message,
+            message:  '' + message,
             scopes:   []
           });
         }
@@ -918,7 +918,13 @@ var makeSignatureValidator = function(options) {
         });
       };
       if (req.authorization) {
-        hawk.server.authenticate(req, function(clientId, callback) {
+        hawk.server.authenticate({
+          method:           req.method,
+          url:              req.resource,
+          host:             req.host,
+          port:             req.port,
+          authorization:    req.authorization
+        }, function(clientId, callback) {
           var ext = undefined;
 
           // Parse authorization header for ext
@@ -948,7 +954,13 @@ var makeSignatureValidator = function(options) {
         }, authenticated);
       } else {
       // If there is no authorization header we'll attempt a login with bewit
-        hawk.uri.authenticate(req, function(clientId, callback) {
+        hawk.uri.authenticate({
+          method:           req.method,
+          url:              req.resource,
+          host:             req.host,
+          port:             req.port,
+          authorization:    req.authorization
+        }, function(clientId, callback) {
           var ext = undefined;
 
           // Get bewit string (stolen from hawk)
@@ -1054,10 +1066,10 @@ var remoteAuthentication = function(options, entry) {
 
     // Send input to auth server
     return Promise.resolve(options.signatureValidator({
-      method:           req.method,
-      url:              req.originalUrl,
+      method:           req.method.toLowerCase(),
+      resource:         req.originalUrl,
       host:             host.name,
-      port:             port,
+      port:             parseInt(port),
       authorization:    req.headers.authorization
     }, options));
   };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "hoek":                             "2.x.x",
     "taskcluster-client":               "0.18.1",
     "json-stable-stringify":            "1.0.0",
-    "buffertools":                      "2.1.2"
+    "buffertools":                      "2.1.2",
+    "cryptiles":                        "^2.0.4"
   },
   "devDependencies": {
     "mocha":                            "2.0.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "hawk":                             "2.3.0",
     "moment":                           "2.9.0",
     "marked":                           "0.3.2",
-    "body-parser":                      "1.8.1",
+    "body-parser":                      "1.13.3",
     "morgan":                           "1.3.0",
     "method-override":                  "2.2.0",
     "cookie-parser":                    "1.3.3",

--- a/test/testing/mockauthserver_test.js
+++ b/test/testing/mockauthserver_test.js
@@ -55,6 +55,22 @@ suite('testing.createMockAuthServer', function() {
       });
   });
 
+  test("Can getCredentials w. auth:credentials (authorizedScopes)", function() {
+    return request
+      .get('http://localhost:1207/v1/client/authed-client/credentials')
+      .hawk({
+        id:         'authed-client',
+        key:        'test-token',
+        algorithm:  'sha256',
+        ext: new Buffer(JSON.stringify({
+          authorizedScopes: ['auth:credentials']
+        })).toString('base64')
+      })
+      .end().then(function(res) {
+        assert(res.ok, "Failed to get credentials");
+      });
+  });
+
   test("Can getCredentials w. auth:credentials (bewit)", function() {
     var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
     var bewit = (hawk.client.getBewit || hawk.client.bewit)(reqUrl, {
@@ -81,6 +97,26 @@ suite('testing.createMockAuthServer', function() {
         key:        'test-token',
         algorithm:  'sha256'
       })
+      .end().then(function(res) {
+        assert(!res.ok, "Request should have failed");
+      });
+  });
+
+  test("Can't ... without auth:credentials (authorizedScopes)", function() {
+    var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
+    var header = hawk.client.header(reqUrl, 'GET', {
+      credentials: {
+        id:         'authed-client',
+        key:        'test-token',
+        algorithm:  'sha256',
+      },
+      ext: new Buffer(JSON.stringify({
+        authorizedScopes: ['auth:credential-']
+      })).toString('base64')
+    });
+    return request
+      .get(reqUrl)
+      .set('Authorization', header.field)
       .end().then(function(res) {
         assert(!res.ok, "Request should have failed");
       });

--- a/test/testing/mockauthserver_test.js
+++ b/test/testing/mockauthserver_test.js
@@ -55,6 +55,42 @@ suite('testing.createMockAuthServer', function() {
       });
   });
 
+  test("Can getCredentials w. auth:credentials (payload hash)", function() {
+    var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
+    var header = hawk.client.header(reqUrl, 'GET', {
+      credentials: {
+        id:         'authed-client',
+        key:        'test-token',
+        algorithm:  'sha256',
+      },
+      payload:      ''
+    });
+    return request
+      .get(reqUrl)
+      .set('Authorization', header.field)
+      .end().then(function(res) {
+        assert(res.ok, "Failed to get credentials");
+      });
+  });
+
+  test("Can getCredentials w. auth:credentials (invalid hash)", function() {
+    var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
+    var header = hawk.client.header(reqUrl, 'GET', {
+      credentials: {
+        id:         'authed-client',
+        key:        'test-token',
+        algorithm:  'sha256',
+      },
+      payload:      'wrong-payload'
+    });
+    return request
+      .get(reqUrl)
+      .set('Authorization', header.field)
+      .end().then(function(res) {
+        assert(!res.ok, "Expected an error");
+      });
+  });
+
   test("Can getCredentials w. auth:credentials (authorizedScopes)", function() {
     var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
     var header = hawk.client.header(reqUrl, 'GET', {

--- a/test/testing/mockauthserver_test.js
+++ b/test/testing/mockauthserver_test.js
@@ -56,16 +56,20 @@ suite('testing.createMockAuthServer', function() {
   });
 
   test("Can getCredentials w. auth:credentials (authorizedScopes)", function() {
-    return request
-      .get('http://localhost:1207/v1/client/authed-client/credentials')
-      .hawk({
+    var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
+    var header = hawk.client.header(reqUrl, 'GET', {
+      credentials: {
         id:         'authed-client',
         key:        'test-token',
         algorithm:  'sha256',
-        ext: new Buffer(JSON.stringify({
-          authorizedScopes: ['auth:credentials']
-        })).toString('base64')
-      })
+      },
+      ext: new Buffer(JSON.stringify({
+        authorizedScopes: ['auth:credentials']
+      })).toString('base64')
+    });
+    return request
+      .get(reqUrl)
+      .set('Authorization', header.field)
       .end().then(function(res) {
         assert(res.ok, "Failed to get credentials");
       });

--- a/test/testing/mockauthserver_test.js
+++ b/test/testing/mockauthserver_test.js
@@ -4,6 +4,7 @@ suite('testing.createMockAuthServer', function() {
   require('superagent-hawk')(require('superagent'));
   var request   = require('superagent-promise');
   var assert    = require('assert');
+  var hawk      = require('hawk');
 
   var helper  = require('../entity/helper');
   var cfg = helper.loadConfig();
@@ -49,6 +50,24 @@ suite('testing.createMockAuthServer', function() {
         key:        'test-token',
         algorithm:  'sha256'
       })
+      .end().then(function(res) {
+        assert(res.ok, "Failed to get credentials");
+      });
+  });
+
+  test("Can getCredentials w. auth:credentials (bewit)", function() {
+    var reqUrl = 'http://localhost:1207/v1/client/authed-client/credentials';
+    var bewit = (hawk.client.getBewit || hawk.client.bewit)(reqUrl, {
+      credentials: {
+        id:         'authed-client',
+        key:        'test-token',
+        algorithm:  'sha256'
+      },
+      ttlSec:       15 * 60,
+      ext:          undefined
+    });
+    return request
+      .get(reqUrl + '?bewit=' + bewit)
       .end().then(function(res) {
         assert(res.ok, "Failed to get credentials");
       });

--- a/testing.js
+++ b/testing.js
@@ -492,7 +492,7 @@ var createMockAuthServer = function(options) {
         authBaseUrl:    options.authBaseUrl
       },
       validator:      validator,
-      signatureValidator: base.API.makeSignatureValidator({
+      signatureValidator: base.API.createSignatureValidator({
         clientLoader: function(clientId) {
           var client = _.find(options.clients, {
             clientId: clientId

--- a/testing.js
+++ b/testing.js
@@ -360,7 +360,7 @@ mockAuthApi.declare({
 
 /** Declare method for signature validation */
 mockAuthApi.declare({
-  method:       'get',
+  method:       'post',
   route:        '/authenticate-hawk',
   name:         'authenticateHawk',
   title:        "Validate Hawk Signature",

--- a/testing.js
+++ b/testing.js
@@ -525,7 +525,11 @@ var createMockAuthServer = function(options) {
     app.use('/v1', router);
 
     // Create server
-    return app.createServer();
+    return app.createServer().then(function(server) {
+      // Time out connections after 500 ms, prevents tests from hanging
+      server.setTimeout(500);
+      return server;
+    });
   });
 };
 

--- a/testing.js
+++ b/testing.js
@@ -443,6 +443,8 @@ var createClientLoader = function(clients) {
   };
 };
 
+
+
 /**
  * Create an mock authentication server for testing
  *
@@ -490,7 +492,17 @@ var createMockAuthServer = function(options) {
         authBaseUrl:    options.authBaseUrl
       },
       validator:      validator,
-      clientLoader:   createClientLoader(options.clients)
+      signatureValidator: base.API.makeSignatureValidator({
+        clientLoader: function(clientId) {
+          var client = _.find(options.clients, {
+            clientId: clientId
+          });
+          if (!client) {
+            throw new Error("No such clientId: " + clientId);
+          }
+          return client;
+        }
+      })
     });
 
     // Mount router

--- a/utils.js
+++ b/utils.js
@@ -25,7 +25,7 @@ exports.listFolder = function(folder, fileList) {
  * of a scope-set.
  */
 exports.validateScopeSets = function(scopesets) {
-  var msg = "scopes must be an array of arrays of strings (disjunctive normal form)";
+  var msg = "scopes must be an array of arrays of strings (disjunctive form)";
   assert(Array.isArray(scopesets), msg);
   assert(scopesets.every(function(conj) {
       return Array.isArray(conj) && conj.every(function(scope) {
@@ -37,8 +37,8 @@ exports.validateScopeSets = function(scopesets) {
 /**
  * Auxiliary function to check if scopePatterns satisfies a scope-set
  *
- * Note that scope-set is an array of arrays of strings on disjunctive normal
- * form without negation. For example:
+ * Note that scope-set is an array of arrays of strings on disjunctive form
+ * without negation. For example:
  *  [['a', 'b'], ['c']]
  *
  * Is satisfied if either,

--- a/utils.js
+++ b/utils.js
@@ -25,7 +25,8 @@ exports.listFolder = function(folder, fileList) {
  * of a scope-set.
  */
 exports.validateScopeSets = function(scopesets) {
-  var msg = "scopes must be an array of arrays of strings (disjunctive form)";
+  var msg = "scopes must be an array of arrays of strings " +
+            "(disjunctive normal form)";
   assert(Array.isArray(scopesets), msg);
   assert(scopesets.every(function(conj) {
       return Array.isArray(conj) && conj.every(function(scope) {
@@ -37,8 +38,8 @@ exports.validateScopeSets = function(scopesets) {
 /**
  * Auxiliary function to check if scopePatterns satisfies a scope-set
  *
- * Note that scope-set is an array of arrays of strings on disjunctive form
- * without negation. For example:
+ * Note that scope-set is an array of arrays of strings on negation-free
+ * disjunctive normal form. For example:
  *  [['a', 'b'], ['c']]
  *
  * Is satisfied if either,


### PR DESCRIPTION
Basically this means that `api.router` doesn't need credentials anymore... It'll just call `auth.taskcluster.net` and have it validate the signature...

Another PR for `auth.taskcluster.net` is out...