### PR TITLE
Modify config to load from home profile correctly

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,13 +48,25 @@ var config = function(options) {
   // Load configuration from file
   if (options.filename) {
     // Config from current working folder if present
-    cfg.file('local', options.filename + '.conf.json');
+    cfg.file('local', {
+      dir:    process.cwd(),
+      file:   options.filename + '.conf.json',
+      search: true
+    });
 
     // User configuration
-    cfg.file('user', '~/.' + options.filename + '.conf.json');
+    cfg.file('user', {
+      dir:    process.env.HOME,
+      file:   '.' + options.filename + '.conf.json',
+      search: true
+    });
 
     // Global configuration
-    cfg.file('global', '/etc/' + options.filename + '.conf.json');
+    cfg.file('global', {
+      dir:    '/etc',
+      file:   options.filename + '.conf.json',
+      search: true
+    });
   }
 
   // Load default values from profile


### PR DESCRIPTION
The behavior of loading configuration files located in the user directory is broken. You can replicate by providing credentials through a configuration file that is located in the user directory, without specifying environmental variables or a local configuration file. 

By changing the format of the nconf.Provider.file call, this will correctly load the configuration file located at `~/<filename>`. This manually specifies the directory to search for the file, instead of providing a full path. 