### PR TITLE
Move tc-base to use taskcluster-client for auth callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "taskcluster-base",
-  "version":      "0.8.4",
+  "version":      "0.8.5",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Common modules for taskcluster components",
   "license":      "MPL-2.0",
@@ -48,7 +48,7 @@
     "url-join":                         "0.0.1",
     "usage":                            "^0.7.0",
     "hoek":                             "2.x.x",
-    "taskcluster-client":               "0.18.1",
+    "taskcluster-client":               "0.22.6",
     "json-stable-stringify":            "1.0.0",
     "buffertools":                      "2.1.2",
     "cryptiles":                        "^2.0.4"


### PR DESCRIPTION
You reviewed this part before... after creating the end-point I updated tc-client to have it :)
Now I'm updating tc-base to use it...
Then I'll update tc-client to use this tc-base to test itself -- circular dependencies are fun :)

And then... I'll update queue, index, etc. to use remote signature validation... 
