### PR TITLE
Minor fix to support context: ['...'], for simple validation

### DIFF
--- a/api.js
+++ b/api.js
@@ -1239,7 +1239,8 @@ var handle = function(handler, context) {
  *   params: {                                      // Patterns for URL params
  *     param1:  /.../,                // Reg-exp pattern
  *     param2(val) { return "..." }   // Function, returns message if invalid
- *   }
+ *   },
+ *   context:       []                // List of required context properties
  * }
  *
  * The API object will only modified by declarations, when `mount` or `publish`
@@ -1252,7 +1253,8 @@ var API = function(options) {
   });
   this._options = _.defaults({}, options, {
     schemaPrefix:   '',
-    paramPatterns:  {}
+    paramPatterns:  {},
+    context:        []
   });
   this._entries = [];
 };
@@ -1398,6 +1400,12 @@ API.prototype.router = function(options) {
     signatureValidator:   createRemoteSignatureValidator({
       authBaseUrl:        options.authBaseUrl || AUTH_BASE_URL
     })
+  });
+
+  // Validate context
+  this._options.context.forEach(function(property) {
+    assert(options.context[property] !== undefined,
+           "Context must have declared property: '" + property + "'");
   });
 
   // Authentication strategy (default to remote authentication)

--- a/test/api/context_test.js
+++ b/test/api/context_test.js
@@ -1,0 +1,104 @@
+suite("API (context)", function() {
+  var base            = require('../../');
+  var assert          = require('assert');
+  var Promise         = require('promise');
+  var request         = require('superagent-promise');
+  var slugid          = require('slugid');
+
+  test("Provides context", function() {
+    // Create test api
+    var api = new base.API({
+      title:        "Test Api",
+      description:  "Another test api"
+    });
+
+    api.declare({
+      method:   'get',
+      route:    '/context/',
+      name:     'getContext',
+      title:    "Test End-Point",
+      description:  "Place we can call to test something",
+    }, function(req, res) {
+      res.status(200).json({myProp: this.myProp});
+    });
+
+    var value = slugid.v4();
+    return base.validator().then(function(validator) {
+      var router = api.router({
+        validator:  validator,
+        context: {
+          myProp: value
+        }
+      });
+
+      var app = base.app({
+        port:       60872,
+        env:        'development',
+        forceSSL:   false,
+        trustProxy: false,
+      });
+
+      app.use('/v1', router);
+
+      return app.createServer();
+    }).then(function(server) {
+
+      return request
+        .get('http://localhost:60872/v1/context')
+        .end()
+        .then(function(res) {
+          assert(res.body.myProp === value);
+        }).then(function () {
+          return server.terminate();
+        }, function(err) {
+          return server.terminate().then(function() {
+            throw err;
+          });
+        });
+    });
+  });
+
+  test("Context properties can be required", function() {
+    // Create test api
+    var api = new base.API({
+      title:        "Test Api",
+      description:  "Another test api",
+      context:      ['prop1', 'prop2']
+    });
+
+    var value = slugid.v4();
+    return base.validator().then(function(validator) {
+      try {
+        api.router({
+          validator:  validator,
+          context: {
+            prop1: "value1"
+          }
+        });
+      } catch (err) {
+        return; // expected error
+      }
+      assert(false, "Expected an error!");
+    });
+  });
+
+  test("Context properties can provided", function() {
+    // Create test api
+    var api = new base.API({
+      title:        "Test Api",
+      description:  "Another test api",
+      context:      ['prop1', 'prop2']
+    });
+
+    var value = slugid.v4();
+    return base.validator().then(function(validator) {
+      api.router({
+        validator:  validator,
+        context: {
+          prop1: "value1",
+          prop2: "value2"
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
API methods like to context...  we should validate that context properties are present...