### PR TITLE
Replace the old config module with the new one

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 // 'testing' and loading code actually takes time.
 var _ = require('lodash');
 _.forIn({
-  config:         'taskcluster-lib-config',
+  config:         'typed-env-config',
   app:            './app',
   validator:      './validator',
   API:            './api',

--- a/package.json
+++ b/package.json
@@ -48,15 +48,16 @@
     "superagent-hawk": "0.0.4",
     "superagent-promise": "0.1.2",
     "taskcluster-client": "0.22.6",
-    "taskcluster-lib-config": "^0.8.8",
     "taskcluster-lib-loader": "0.0.7",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
+    "typed-env-config": "^0.10.0",
     "url-join": "0.0.1",
     "usage": "^0.7.0",
     "uuid": "1.4.1"
   },
   "devDependencies": {
+    "taskcluster-lib-config": "^0.8.8",
     "mocha": "2.0.1"
   }
 }

--- a/test/api/publish_test.js
+++ b/test/api/publish_test.js
@@ -1,5 +1,6 @@
 suite("api/publish", function() {
   var base            = require('../../');
+  var config  = require('taskcluster-lib-config');
   var aws             = require('aws-sdk-promise');
   var assert          = require('assert');
   var Promise         = require('promise');
@@ -17,7 +18,7 @@ suite("api/publish", function() {
 
   // Test publish reference from mockAuthServer
   test("publish reference from mockAuthServer", function() {
-    var cfg = base.config({
+    var cfg = config({
       envs: [
         'aws_accessKeyId',
         'aws_secretAccessKey',
@@ -58,7 +59,7 @@ suite("api/publish", function() {
 
   // Test simple method
   test("publish minimal reference", function() {
-    var cfg = base.config({
+    var cfg = config({
       envs: [
         'aws_accessKeyId',
         'aws_secretAccessKey',

--- a/test/api/responsetimer_test.js
+++ b/test/api/responsetimer_test.js
@@ -5,11 +5,12 @@ suite("api/responsetimer", function() {
   var Promise         = require('promise');
   var mockAuthServer  = require('../mockauthserver');
   var base            = require('../../');
+  var config  = require('taskcluster-lib-config');
   var express         = require('express');
   var path            = require('path');
 
   // Load necessary configuration
-  var cfg = base.config({
+  var cfg = config({
     envs: [
       'influxdb_connectionString',
     ],

--- a/test/entity/helper.js
+++ b/test/entity/helper.js
@@ -1,9 +1,10 @@
 var base    = require('../../');
+var config  = require('taskcluster-lib-config');
 
 /** Load configuration */
 var loadConfig = function() {
   // Load test configuration
-  var cfg = base.config({
+  var cfg = config({
     envs: [
       'azure_accountName',
       'azure_accountKey',

--- a/test/exchanges_publish_test.js
+++ b/test/exchanges_publish_test.js
@@ -1,10 +1,11 @@
 suite("Exchanges", function() {
   var assert  = require('assert');
   var base    = require('../');
+  var config  = require('taskcluster-lib-config');
   var aws     = require('aws-sdk-promise');
 
   test("publish", function() {
-    var cfg = base.config({
+    var cfg = config({
       envs: [
         'aws_accessKeyId',
         'aws_secretAccessKey',

--- a/test/legacyentity_test.js
+++ b/test/legacyentity_test.js
@@ -4,10 +4,11 @@ suite("LegacyEntity", function() {
   var _       = require('lodash');
   var Promise = require('promise');
   var base    = require('../');
+  var config  = require('taskcluster-lib-config');
   var debug   = require('debug')('base:test:entity');
 
   // Load test configuration
-  var cfg = base.config({
+  var cfg = config({
     envs: [
       'azure_accountName',
       'azure_accountKey',

--- a/test/pulsepublisher_test.js
+++ b/test/pulsepublisher_test.js
@@ -1,6 +1,7 @@
 suite("Exchanges (Publish on Pulse)", function() {
   var assert  = require('assert');
   var base    = require('../');
+  var config  = require('taskcluster-lib-config');
   var path    = require('path');
   var fs      = require('fs');
   var debug   = require('debug')('base:test:publish-pulse');
@@ -9,7 +10,7 @@ suite("Exchanges (Publish on Pulse)", function() {
   var amqplib  = require('amqplib');
 
   // Load necessary configuration
-  var cfg = base.config({
+  var cfg = config({
     envs: [
       'influxdb_connectionString',
     ],

--- a/test/pulsepublisherschemaprefix_test.js
+++ b/test/pulsepublisherschemaprefix_test.js
@@ -1,6 +1,7 @@
 suite("Exchanges (Publish on Pulse w. schemaPrefix)", function() {
   var assert  = require('assert');
   var base    = require('../');
+  var config  = require('taskcluster-lib-config');
   var path    = require('path');
   var fs      = require('fs');
   var debug   = require('debug')('base:test:publish-pulse');
@@ -9,7 +10,7 @@ suite("Exchanges (Publish on Pulse w. schemaPrefix)", function() {
   var amqplib  = require('amqplib');
 
   // Load necessary configuration
-  var cfg = base.config({
+  var cfg = config({
     envs: [
       'influxdb_connectionString',
     ],

--- a/test/testing/pulsetestreceiver_test.js
+++ b/test/testing/pulsetestreceiver_test.js
@@ -2,6 +2,7 @@
 
 suite('testing.PulseTestReceiver', function() {
   var base          = require('../../');
+  var config        = require('taskcluster-lib-config');
   var assert        = require('assert');
   var path          = require('path');
   var fs            = require('fs');
@@ -9,7 +10,7 @@ suite('testing.PulseTestReceiver', function() {
   var taskcluster   = require('taskcluster-client')
 
   // Load necessary configuration
-  var cfg = base.config({
+  var cfg = config({
     filename:               'taskcluster-base-test'
   });
 

--- a/test/validator_publish_test.js
+++ b/test/validator_publish_test.js
@@ -3,11 +3,12 @@ suite("validator", function() {
   var path    = require('path');
   var aws     = require('aws-sdk-promise');
   var base    = require('../');
+  var config  = require('taskcluster-lib-config');
   var http    = require('http');
 
 
   test("test publish", function() {
-    var cfg = base.config({
+    var cfg = config({
       envs: [
         'aws_accessKeyId',
         'aws_secretAccessKey',


### PR DESCRIPTION
You'll notice that the old taskcluster-lib-config is a development dependency.  I don't want to scope creep too much and confuse splitting up the libraries with fixing all the problems.  Since the usage of the old config module is limited to the unit tests and not production code, I think we're OK to work like this for a short time.