### PR TITLE
Ensure that whatever we *would* lazy load is actually resolvable

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ _.forIn({
   scopes:         'taskcluster-lib-scopes',
   utils:          './utils'
 }, function(module, name) {
+  require.resolve(module);
   Object.defineProperty(exports, name, {
     enumerable: true,
     get:        function() { return require(module); }


### PR DESCRIPTION
Basically, we still want to lazy load, but let's double check that we're
not adding things to index.js that cannot be resolved