### PR TITLE
Add taskcluster-lib-monitor

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ _.forIn({
   loader:         'taskcluster-lib-loader',
   Exchanges:      'pulse-publisher',
   testing:        'taskcluster-lib-testing',
+  monitor:        'taskcluster-lib-monitor',
   stats:          'taskcluster-lib-stats',
   scopes:         'taskcluster-lib-scopes',
 }, function(module, name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-base",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "Common modules for taskcluster components",
   "license": "MPL-2.0",
@@ -20,6 +20,7 @@
     "taskcluster-lib-app": "^0.8.9",
     "taskcluster-lib-legacyentities": "^0.8.7",
     "taskcluster-lib-loader": "^0.1.0",
+    "taskcluster-lib-monitor": "^0.2.1",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
     "taskcluster-lib-testing": "^0.11.1",


### PR DESCRIPTION
Like it says on the tin.

Do we want to deprecate tc-lib-stats now that this is going in or does it provide something else we find useful?

I'm also integrating this with tc-lib-api now.