### PR TITLE
Bump to 1.0 along with new monitor-ready libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: node_js
 node_js:
 - '0.12'
+- '4'
+- '5'
+env:
+  global:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 
 # encrpyt channel name to get around issue
 # https://github.com/travis-ci/travis-ci/issues/1094

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ _.forIn({
   Exchanges:      'pulse-publisher',
   testing:        'taskcluster-lib-testing',
   monitor:        'taskcluster-lib-monitor',
-  stats:          'taskcluster-lib-stats',
   scopes:         'taskcluster-lib-scopes',
 }, function(module, name) {
   require.resolve(module);
@@ -30,6 +29,7 @@ _.forIn({
 _.forIn({
   LegacyEntity:   'taskcluster-lib-legacyentities',
   AzureAgent:     'taskcluster-lib-legacyentities/azureagent',
+  stats:          'taskcluster-lib-stats',
   utils:          './utils'
 }, function(module, name) {
   require.resolve(module);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "azure-entities": "^1.0.0",
     "lodash": "^4.12.0",
-    "pulse-publisher": "^1.0.0",
+    "pulse-publisher": "^1.0.1",
     "taskcluster-client": "0.23.4",
     "taskcluster-lib-api": "^1.0.0",
     "taskcluster-lib-app": "^0.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-base",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "Common modules for taskcluster components",
   "license": "MPL-2.0",
@@ -12,15 +12,15 @@
     "url": "https://github.com/taskcluster/taskcluster-base.git"
   },
   "dependencies": {
-    "azure-entities": "^0.9.1",
-    "lodash": "^3.10.1",
-    "pulse-publisher": "^0.9.0",
+    "azure-entities": "^1.0.0",
+    "lodash": "^4.12.0",
+    "pulse-publisher": "^1.0.0",
     "taskcluster-client": "0.23.4",
-    "taskcluster-lib-api": "^0.12.0",
+    "taskcluster-lib-api": "^1.0.0",
     "taskcluster-lib-app": "^0.8.9",
     "taskcluster-lib-legacyentities": "^0.8.7",
     "taskcluster-lib-loader": "^0.1.0",
-    "taskcluster-lib-monitor": "^0.4.0",
+    "taskcluster-lib-monitor": "^1.0.1",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
     "taskcluster-lib-testing": "^0.11.1",


### PR DESCRIPTION
Wanted to get this one reviewed since I moved tc-lib-stats to deprecated.