### PR TITLE
Allow travis to publish new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,11 @@ notifications:
       - "Change view : %{compare_url}"
       - "Build details : %{build_url}"
       - "Commit message : %{commit_message}"
+deploy:
+  provider: npm
+  email: taskcluster-accounts@mozilla.com
+  api_key:
+    secure: E/5EYAIQ6QKA1zSO3iN9hAZseztdvB0Ucb58IUWiDFRc1mz5KNiJnWy1WaJSNAfzZ6uXvdHjYPoFw/fyMsnev9Cg34pyC12h9VoDOKEXRdWw5qf+50SDEJLG0pfsA5EcEz946P8/GZxMPifuAyBgH4WjIF0Cn+H1NOgeB5Cj
+  on:
+    tags: true
+    repo: taskcluster/taskcluster-base

--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ TaskCluster Base Modules
 <img src="https://tools.taskcluster.net/lib/assets/taskcluster-120.png" />
 
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-base.svg?branch=master)](http://travis-ci.org/taskcluster/taskcluster-base)
+[![npm](https://img.shields.io/npm/v/taskcluster-base.svg?maxAge=2592000)](https://www.npmjs.com/package/taskcluster-base)
 [![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](https://github.com/taskcluster/taskcluster-base/blob/master/LICENSE)
 
 A collection of common modules used many taskcluster components.
 
 Most of the modules in this _base_ collection can be instantiated by providing
 a JSON dictionary with configuration and parameters.
+
+
+Updating
+--------
+
+There is no need (and in fact it should be impossible) to manually publish a new version of this package.
+Upon pushing an appropriately tagged version to Github, Travis will pick this up and deploy a new version
+for you, assuming the tests pass. New versions should be created with `npm version` rather than by
+manually editing `package.json` and tags should be pushed to Github.
 
 
 Code Conventions


### PR DESCRIPTION
This would cut down on the amount of work I need to do when I publish a new package included in this package. I've been using the travis publishing stuff for tc-lib-monitor and tc-lib-validate for a month or so now with no issues. If we accept this in, I'll go update the settings needed in npmjs.com as well. 