### PR TITLE
[NOT_READY_YET] Make it impossible to use taskcluster-base with aws-sdk-promise installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,32 @@
 "use strict";
+var util = require('util');
+
+var awsSdkPromise;
+try {
+  awsSdkPromise = require.resolve('aws-sdk-promise');
+  awsSdkPromise = [
+    'Your environment can resolve the \'aws-sdk-promise\' ',
+    'library.  This is a bad thing because it means that ',
+    'code in your environment import and be broken by it.  ',
+    'What happens is that it overwrites the global \'aws-sdk\' ',
+    '.promise() method with its own version.  Now that the ',
+    'upstream library has a promise implementation, use it.  ',
+    'Do note that you must remove the .data lookup on the ',
+    'resolution value of api calls with the upstream library.',
+    '',
+    '\nFound aws-sdk-promise here: ' + awsSdkPromise,
+  ].join('');
+
+  console.log(msg);
+} catch (err) { }
+
+if (awsSdkPromise) {
+  throw new Error(awsSdkPromise);
+}
 
 // Lazy load all submodules, not many production systems need to load
 // 'testing' and loading code actually takes time.
 var _ = require('lodash');
-var util = require('util');
 _.forIn({
   config:         'typed-env-config',
   app:            'taskcluster-lib-app',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "azure-entities": "^1.0.2",
     "lodash": "^4.12.0",
-    "pulse-publisher": "^1.0.1",
+    "pulse-publisher": "^2.0.0",
     "taskcluster-client": "1.0.1",
     "taskcluster-lib-api": "^2.0.0",
     "taskcluster-lib-app": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-base",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "Common modules for taskcluster components",
   "license": "MPL-2.0",
@@ -16,7 +16,7 @@
     "lodash": "^4.12.0",
     "pulse-publisher": "^1.0.1",
     "taskcluster-client": "1.0.1",
-    "taskcluster-lib-api": "^1.1.0",
+    "taskcluster-lib-api": "^2.0.0",
     "taskcluster-lib-app": "^1.0.0",
     "taskcluster-lib-docs": "^1.0.3",
     "taskcluster-lib-iterate": "^1.0.0",


### PR DESCRIPTION
We should make taskcluster-base official incompatible with aws-sdk-promise being importable.  We'll need to update at least pulse-publisher still to stop using aws-sdk-promise.  Not sure why lib-api is showing as still referring to aws-sdk-promise

``` sh
jhford:~/taskcluster/taskcluster-base $ find node_modules/ -type f -exec grep -l aws-sdk-promise {} + 
node_modules/pulse-publisher/src/exchanges.js
node_modules/pulse-publisher/package.json
node_modules/pulse-publisher/lib/exchanges.js.map
node_modules/pulse-publisher/lib/exchanges.js
node_modules/pulse-publisher/.test/exchanges_publish_test.js.map
node_modules/pulse-publisher/.test/exchanges_publish_test.js
node_modules/pulse-publisher/test/exchanges_publish_test.js
node_modules/aws-sdk-promise/node_modules/promise/package.json
node_modules/aws-sdk-promise/node_modules/asap/package.json
node_modules/aws-sdk-promise/package.json
node_modules/aws-sdk-promise/README.md
node_modules/aws-sdk-promise/index.js
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/src/api.js
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/package.json
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/lib/api.js
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/lib/api.js.map
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/.test/publish_test.js.map
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/.test/publish_test.js
node_modules/taskcluster-base/node_modules/taskcluster-lib-api/test/publish_test.js
node_modules/taskcluster-base/package.json
```
